### PR TITLE
compiled on macOS m1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,16 @@ if (NOT CMAKE_BUILD_TYPE STREQUAL "Release")
   set(CMAKE_BUILD_TYPE "Debug")
 endif()
 
+# customized platform checking flags
+set(VGG_CPU_ARCH "X86_64")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "^arm" OR CMAKE_SYSTEM_PROCESSOR MATCHES "^aarch64")
+if(APPLE)
+    set(VGG_PLATFORM "MACOS")
+	set(VGG_CPU_ARCH "ARM")
+endif()
+endif()
+
+
 # find system libs
 if (NOT EMSCRIPTEN)
   # find OpenGL library

--- a/lib/skia/CMakeLists.txt
+++ b/lib/skia/CMakeLists.txt
@@ -1016,6 +1016,7 @@ if (NOT EMSCRIPTEN)
     "src/opts/SkOpts_avx.cpp"
     "src/opts/SkOpts_hsw.cpp"
     "src/opts/SkOpts_skx.cpp"
+    "src/opts/SkOpts_crc32.cpp"
   )
   add_library(skia SHARED ${SKIA_SRCS})
   target_compile_options(skia PRIVATE

--- a/lib/skia/third_party/externals/CMakeLists.txt
+++ b/lib/skia/third_party/externals/CMakeLists.txt
@@ -32,10 +32,13 @@ if (NOT EMSCRIPTEN)
   )
 endif()
 add_library(zlib SHARED ${ZLIB_SRCS})
+
 if (NOT EMSCRIPTEN)
-  set_target_properties(zlib PROPERTIES
-    COMPILE_FLAGS "-msse3 -msse4.2 -mpclmul -DX86_NOT_WINDOWS -DADLER32_SIMD_SSSE3 -DCRC32_SIMD_SSE42_PCLMUL -DDEFLATE_FILL_WINDOW_SSE2"
-  )
+    if(VGG_CPU_ARCH MATCHES "X86_64")
+    set_target_properties(zlib PROPERTIES
+      COMPILE_FLAGS "-msse3 -msse4.2 -mpclmul -DX86_NOT_WINDOWS -DADLER32_SIMD_SSSE3 -DCRC32_SIMD_SSE42_PCLMUL -DDEFLATE_FILL_WINDOW_SSE2"
+    )
+  endif()
 endif()
 target_include_directories(zlib PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/zlib
@@ -68,10 +71,18 @@ if (NOT EMSCRIPTEN)
   )
 endif()
 add_library(libpng SHARED ${LIBPNG_SRCS})
+if(VGG_CPU_ARCH STREQUAL "ARM" AND VGG_PLATFORM STREQUAL "MACOS")
+  # It seems that CMakeLists.txt in libpng directory is not used.
+  # On Apple silicon, the optimization for arm must be off or result in link error.
+  add_definitions(-DPNG_ARM_NEON_OPT=0)
+endif()
 if (NOT EMSCRIPTEN)
+  # On arm64, it also could be compiled with PNG_INTEL_SSE.
+  if(VGG_CPU_ARCH STREQUAL "X86_64")
   set_target_properties(libpng PROPERTIES
     COMPILE_FLAGS "-DPNG_INTEL_SSE"
   )
+  endif()
 endif()
 add_custom_target(libpng_config
   COMMAND "${CMAKE_COMMAND}" -E copy_if_different


### PR DESCRIPTION
Make it compiled on Apple Silicon.
- Add cpu architecture detection to determine SSE optimization.
- Some intrinsics optimizations on ARM for libpng is not allowed on Apple M1, leading to link error. Disable PNG_ARM_NEON_OPT seems the easiest way.