### PR TITLE
Refactor for reusing easily

### DIFF
--- a/src/Entity/EntityManager.hpp
+++ b/src/Entity/EntityManager.hpp
@@ -84,7 +84,8 @@ public:
     return entities->push(Entity{});
   }
 
-  static inline void map(std::function<void(Entity&)> fn)
+  template<typename F>
+  static inline void map(F&& fn)
   {
     auto entities = EntityManager::getInstance()->entities;
     ASSERT(entities);
@@ -94,7 +95,8 @@ public:
     }
   }
 
-  static inline void mapR(std::function<void(Entity&)> fn)
+  template<typename F>
+  static inline void mapR(F&& fn)
   {
     auto entities = EntityManager::getInstance()->entities;
     ASSERT(entities);
@@ -104,7 +106,8 @@ public:
     }
   }
 
-  static inline bool scan(std::function<bool(Entity&)> fn)
+  template<typename F>
+  static inline bool scan(F&& fn)
   {
     auto entities = EntityManager::getInstance()->entities;
     ASSERT(entities);
@@ -118,7 +121,8 @@ public:
     return false;
   }
 
-  static inline bool scanR(std::function<bool(Entity&)> fn)
+  template<typename F>
+  static inline bool scanR(F&& fn)
   {
     auto entities = EntityManager::getInstance()->entities;
     ASSERT(entities);

--- a/src/Utils/App.hpp
+++ b/src/Utils/App.hpp
@@ -47,36 +47,50 @@ namespace VGG
 /** App
  *
  * A singleton app class which provides:
- * 1. A single SDL window with OpenGL/ES context for skia.
+ * 1. A single OpenGL/ES context for skia.
  * 2. Auto pixel ratio support.
  * 3. Basic events support.
  *
+ * CRTP: the following methods must be implemented in T to integrate custome window manager
+ * bool initContext(int, int, const std::string&)
+ *     It should guarantee the GL context properly created.
+ *
+ * bool makeContextCurrent()
+ *     It should switch the GL context in current thread after invoke.
+ *
+ * std::any getProperty(const std::string &):
+ *         It should return the properties about the T 
+ *         "window_w" "window_h", "app_w", "app_h" "viewport_w" "viewport_h"
+ *
+ * void swapBuffer():
+ *         swaps the buffer
+ *
+ * void onInit():
+ *         Invoked after all init processes complete.
+ *
+ * void pollEvent():
+ *         It will be invoked in every frame to poll event.
+ *         dispatchEvent() and dispatchGlobalEvent() must be processed properly in pollEvent()
+ *
+ * SDL event struct is adopted as our event handler framework, sdl runtime is not necessary for App
+ *
  * NOTE:
  * It must be derived to use this class, and the singleton app
- * instance can be obtained by App::getIntance<DerivedApp>().
+ * instance can be obtained by App<DerivedApp>::getIntance<DerivedApp>().
  */
 
 template<typename T>
 class App : public Uncopyable
 {
-// CRTP:
-// T must be implementes the following methods
-// initContext
-// makeContextCurrent
-// getProperty
-// swapBuffer
-// onInit
-// pollEvent
-// and dispatchEvent and dispatchGlobalEvent must be called properly to in pollEvent
 private:
-  inline void initContext(int w, int h, const std::string& title)
+  inline bool initContext(int w, int h, const std::string& title)
   {
-    static_cast<T*>(this)->initContext(w, h, title);
+    return static_cast<T*>(this)->initContext(w, h, title);
   }
 
-  inline void makeContextCurrent()
+  inline bool makeContextCurrent()
   {
-    static_cast<T*>(this)->makeContextCurrent();
+    return static_cast<T*>(this)->makeContextCurrent();
   }
 
   inline std::any getProperty(const std::string& name)

--- a/src/Utils/App.hpp
+++ b/src/Utils/App.hpp
@@ -235,17 +235,15 @@ protected: // protected members and static members
     app->m_skiaState.grContext = grContext;
 
     // get necessary property about window and DPI
-    int dw = std::any_cast<int>(app->getProperty("viewport_w"));
-    int dh = std::any_cast<int>(app->getProperty("viewport_h"));
-    int ww = std::any_cast<int>(app->getProperty("window_w"));
-    int wh = std::any_cast<int>(app->getProperty("window_h"));
+    auto drawSize = std::any_cast<std::pair<int, int>>(app->getProperty("viewport_size"));
+    auto winSize = std::any_cast<std::pair<int, int>>(app->getProperty("window_size"));
 
-    DEBUG("Drawable size: %d %d", dw, dh);
-    DEBUG("Window size: %d %d", ww, wh);
+    DEBUG("Drawable size: %d %d", drawSize.first, drawSize.second);
+    DEBUG("Window size: %d %d", winSize.first, winSize.second);
 #ifdef __linux__
     app->m_pixelRatio = DPI::ScaleFactor;
 #else
-    app->m_pixelRatio = (double)dw / ww;
+    app->m_pixelRatio = (double)drawSize.first / winSize.first;
 #endif
     DEBUG("Scale factor: %.2lf", DPI::ScaleFactor);
     DEBUG("Pixel ratio: %.2lf", app->m_pixelRatio);

--- a/src/Utils/App.hpp
+++ b/src/Utils/App.hpp
@@ -53,24 +53,24 @@ namespace VGG
  *
  * CRTP: the following methods must be implemented in T to integrate custome window manager
  * bool initContext(int, int, const std::string&)
- *     It should guarantee the GL context properly created.
+ *	   It should guarantee the GL context properly created.
  *
  * bool makeContextCurrent()
- *     It should switch the GL context in current thread after invoke.
+ *	   It should switch the GL context in current thread after invoke.
  *
  * std::any getProperty(const std::string &):
- *         It should return the properties about the T 
- *         "window_w" "window_h", "app_w", "app_h" "viewport_w" "viewport_h"
+ *		   It should return the properties about the T
+ *		   "window_w" "window_h", "app_w", "app_h" "viewport_w" "viewport_h"
  *
  * void swapBuffer():
- *         swaps the buffer
+ *		   swaps the buffer
  *
  * void onInit():
- *         Invoked after all init processes complete.
+ *		   Invoked after all init processes complete.
  *
  * void pollEvent():
- *         It will be invoked in every frame to poll event.
- *         dispatchEvent() and dispatchGlobalEvent() must be processed properly in pollEvent()
+ *		   It will be invoked in every frame to poll event.
+ *		   dispatchEvent() and dispatchGlobalEvent() must be processed properly in pollEvent()
  *
  * SDL event struct is adopted as our event handler framework, sdl runtime is not necessary for App
  *
@@ -234,23 +234,7 @@ protected: // protected members and static members
     app->m_skiaState.interface = interface;
     app->m_skiaState.grContext = grContext;
 
-    // get skia surface and canvas
-    sk_sp<SkSurface> surface = app->setup_skia_surface(w, h);
-    if (!surface)
-    {
-      FAIL("Failed to make skia surface.");
-      return false;
-    }
-    app->m_skiaState.surface = surface;
-    SkCanvas* canvas = surface->getCanvas();
-    if (!canvas)
-    {
-      FAIL("Failed to get skia canvas.");
-      return false;
-    }
-
     // get necessary property about window and DPI
-    //
     int dw = std::any_cast<int>(app->getProperty("viewport_w"));
     int dh = std::any_cast<int>(app->getProperty("viewport_h"));
     int ww = std::any_cast<int>(app->getProperty("window_w"));
@@ -265,6 +249,21 @@ protected: // protected members and static members
 #endif
     DEBUG("Scale factor: %.2lf", DPI::ScaleFactor);
     DEBUG("Pixel ratio: %.2lf", app->m_pixelRatio);
+
+    // get skia surface and canvas
+    sk_sp<SkSurface> surface = app->setup_skia_surface(w, h);
+    if (!surface)
+    {
+      FAIL("Failed to make skia surface.");
+      return false;
+    }
+    app->m_skiaState.surface = surface;
+    SkCanvas* canvas = surface->getCanvas();
+    if (!canvas)
+    {
+      FAIL("Failed to get skia canvas.");
+      return false;
+    }
 
     // extra initialization
     app->onInit();
@@ -332,6 +331,8 @@ protected: // protected methods
     {
       int w = window.data1 / DPI::ScaleFactor;
       int h = window.data2 / DPI::ScaleFactor;
+
+      DEBUG("Window resizing: (%d %d)", w, h);
       m_skiaState.surface = setup_skia_surface(w, h);
       m_width = w;
       m_height = h;
@@ -463,7 +464,7 @@ public: // public methods
       return;
     }
 #if 0
-    INFO("frame %d", m_nFrame++);
+	INFO("frame %d", m_nFrame++);
 #endif
 
     pollEvent();

--- a/src/Utils/App.hpp
+++ b/src/Utils/App.hpp
@@ -123,6 +123,8 @@ HAS_MEMBER_FUNCTION_DEF(onInit)
  * */
 HAS_MEMBER_FUNCTION_DEF(pollEvent)
 
+#undef HAS_MEMBER_FUNCTION_DEF
+
 template<typename T>
 class App : public Uncopyable
 {

--- a/src/Utils/App.hpp
+++ b/src/Utils/App.hpp
@@ -81,9 +81,9 @@ namespace VGG
  */
 
 /*
- * void initContext();
- * Init the opengl context
- * */
+ * bool initContext(int, int, const std::string&)
+ *	It should guarantee the GL context properly created.
+ *	*/
 HAS_MEMBER_FUNCTION_DEF(initContext)
 /*
  * bool makeContextCurrent()
@@ -116,10 +116,11 @@ HAS_MEMBER_FUNCTION_DEF(swapBuffer)
  *	Invoked after all init processes complete.
  * */
 HAS_MEMBER_FUNCTION_DEF(onInit)
+
 /*
- * bool initContext(int, int, const std::string&)
- *	It should guarantee the GL context properly created.
- *	*/
+ * void pollEvent()
+ * Polls the backends events
+ * */
 HAS_MEMBER_FUNCTION_DEF(pollEvent)
 
 template<typename T>

--- a/src/Utils/App.hpp
+++ b/src/Utils/App.hpp
@@ -495,12 +495,11 @@ public: // public methods
   }
 
 public: // public static methods
-  template<typename DerivedApp>
-  static DerivedApp* getInstance(int w = 800, int h = 600, const std::string& title = "App")
+  static T* getInstance(int w = 800, int h = 600, const std::string& title = "App")
   {
-    static_assert(std::is_base_of<App<DerivedApp>, DerivedApp>());
+    static_assert(std::is_base_of<App<T>, T>());
 
-    static DerivedApp app;
+    static T app;
 
     // if already initialized, these init params are ignored
     if (!init(&app, w, h, title))

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -16,186 +16,227 @@
  */
 #include <argparse/argparse.hpp>
 #include <algorithm>
+#include <filesystem>
 #include <nlohmann/json.hpp>
 
 #include "Entity/EntityManager.hpp"
 #include "Entity/InputManager.hpp"
 #include "Systems/RenderSystem.hpp"
 #include "Utils/App.hpp"
-#include "Utils/FileManager.hpp"
+#include "Utils/Utils.hpp"
 #include "Utils/Version.hpp"
-#include "Utils/Scheduler.hpp"
 
 using namespace VGG;
 
-class Runtime : public App
+class SDLRuntime : public App<SDLRuntime>
 {
-  struct Zoomer
+  struct SDLState
   {
-    static constexpr double minZoom = 0.01;
-    static constexpr double maxZoom = 10.0;
-    Vec2 offset{ 0.0, 0.0 };
-    double zoom{ 1.0 };
-    bool panning{ false };
-
-    void apply(SkCanvas* canvas)
-    {
-      ASSERT(canvas);
-      canvas->translate(offset.x, offset.y);
-      canvas->scale(zoom, zoom);
-    }
-
-    void restore(SkCanvas* canvas)
-    {
-      ASSERT(canvas);
-      canvas->scale(1. / zoom, 1. / zoom);
-      canvas->translate(-offset.x, -offset.y);
-    }
-
-    SDL_Event mapEvent(SDL_Event evt, double scaleFactor)
-    {
-      if (evt.type == SDL_MOUSEMOTION)
-      {
-        double x1 = evt.motion.x;
-        double y1 = evt.motion.y;
-        double x0 = x1 - evt.motion.xrel;
-        double y0 = y1 - evt.motion.yrel;
-        x1 = (x1 / scaleFactor - offset.x) / zoom;
-        y1 = (y1 / scaleFactor - offset.y) / zoom;
-        x0 = (x0 / scaleFactor - offset.x) / zoom;
-        y0 = (y0 / scaleFactor - offset.y) / zoom;
-        evt.motion.x = FLOAT2SINT(x1);
-        evt.motion.y = FLOAT2SINT(y1);
-        evt.motion.xrel = FLOAT2SINT(x1 - x0);
-        evt.motion.yrel = FLOAT2SINT(y1 - y0);
-      }
-      return evt;
-    }
+    SDL_Window* window{ nullptr };
+    SDL_GLContext glContext{ nullptr };
   };
-  Zoomer m_zoomer;
+  SDLState m_sdlState;
+  std::unordered_map<std::string, std::any> m_properties;
 
 public:
-  inline void setOnFrameOnce(std::function<void()>&& cb)
+  static inline void handle_sdl_error()
   {
-    Scheduler::setOnFrameOnce(std::move(cb));
+    const char* err = SDL_GetError();
+    FAIL("SDL Error: %s", err);
+    SDL_ClearError();
   }
 
-  inline void startRunMode()
+#ifdef __linux__
+  static double get_scale_factor()
   {
-    EntityManager::setInteractionMode(EntityManager::InteractionMode::RUN);
-    InputManager::setMouseCursor(MouseEntity::CursorType::NORMAL);
-    if (auto container = EntityManager::getEntities())
+    static constexpr int NVARS = 4;
+    static const char* vars[NVARS] = {
+      "FORCE_SCALE",
+      "QT_SCALE_FACTOR",
+      "QT_SCREEN_SCALE_FACTOR",
+      "GDK_SCALE",
+    };
+    for (int i = 0; i < NVARS; i++)
     {
-      container->setRunModeInteractions();
+      const char* strVal = getenv(vars[i]);
+      if (strVal)
+      {
+        double val = atof(strVal);
+        if (val >= 1.0)
+        {
+          return val;
+        }
+      }
     }
+    return 1.0;
+  }
+#else
+  static inline double get_scale_factor()
+  {
+    return 1.0;
+  }
+#endif
+  bool initContext(int w, int h, const std::string& title)
+  {
+    // init sdl
+    if (SDL_Init(SDL_INIT_VIDEO) != 0)
+    {
+      handle_sdl_error();
+      return false;
+    }
+    SDL_version compileVersion, linkVersion;
+    SDL_VERSION(&compileVersion);
+    SDL_GetVersion(&linkVersion);
+    INFO("SDL version %d.%d.%d (linked %d.%d.%d)",
+         compileVersion.major,
+         compileVersion.minor,
+         compileVersion.patch,
+         linkVersion.major,
+         linkVersion.minor,
+         linkVersion.patch);
+
+    // setup opengl properties
+    SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_BUFFER_SIZE, 1);
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+    SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, N_STENCILBITS);
+    SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1);
+    SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 0);
+    SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, N_MULTISAMPLE);
+#ifndef EMSCRIPTEN
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+#else
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+    SDL_SetHint(SDL_HINT_EMSCRIPTEN_KEYBOARD_ELEMENT, "#canvas");
+#endif
+
+    // create window
+    DPI::ScaleFactor = get_scale_factor();
+    int winWidth = w * DPI::ScaleFactor;
+    int winHeight = h * DPI::ScaleFactor;
+    SDL_Window* window =
+#ifndef EMSCRIPTEN
+      SDL_CreateWindow(title.c_str(),
+#else
+      SDL_CreateWindow(nullptr,
+#endif
+                       SDL_WINDOWPOS_CENTERED,
+                       SDL_WINDOWPOS_CENTERED,
+                       winWidth,
+                       winHeight,
+                       SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+    if (!window)
+    {
+      handle_sdl_error();
+      return false;
+    }
+    m_width = w;
+    m_height = h;
+    m_sdlState.window = window;
+    // create context
+    SDL_GLContext glContext = SDL_GL_CreateContext(window);
+    if (!glContext)
+    {
+      handle_sdl_error();
+      return false;
+    }
+
+    m_sdlState.glContext = glContext;
+
+    if (makeContextCurrent() == false)
+    {
+      return false;
+    }
+
+    // switch to this context
+    INFO("GL_VENDOR: %s", glGetString(GL_VENDOR));
+    INFO("GL_RENDERER: %s", glGetString(GL_RENDERER));
+    INFO("GL_VERSION: %s", glGetString(GL_VERSION));
+    INFO("GL_SHADING_LANGUAGE_VERSION: %s", glGetString(GL_SHADING_LANGUAGE_VERSION));
+
+    // get device pixel ratio
+    int dw = 0, dh = 0;
+    int ww = 0, wh = 0;
+    SDL_GL_GetDrawableSize(window, &dw, &dh);
+    SDL_GetWindowSize(window, &ww, &wh);
+    m_properties["viewport_w"] = dw;
+    m_properties["viewport_h"] = dh;
+    m_properties["window_w"] = ww;
+    m_properties["window_h"] = wh;
+    return true;
   }
 
-protected:
-  virtual void onInit() override
+  bool makeContextCurrent()
   {
+    WARN("makeContextCurrent");
+    if (SDL_GL_MakeCurrent(m_sdlState.window, m_sdlState.glContext) != 0)
+    {
+      handle_sdl_error();
+      return false;
+    }
+    return true;
+  }
+
+  std::any getProperty(const std::string& name)
+  {
+    return m_properties[name];
+  }
+
+  void onInit()
+  {
+    SDL_GL_SetSwapInterval(0);
     SDL_ShowCursor(SDL_DISABLE);
   }
 
-  virtual void onFrame() override
+  void pollEvent()
   {
-    Scheduler::callOnFrameOnce();
-
-    if (SkCanvas* canvas = getCanvas())
+    SDL_Event evt;
+    while (SDL_PollEvent(&evt))
     {
-      m_zoomer.apply(canvas);
-      EntityManager::map([&](Entity& entity) { RenderSystem::drawEntity(canvas, entity); });
-      InputManager::draw(canvas);
-      m_zoomer.restore(canvas);
-    }
+      // process global events like shortcuts first
+      if (dispatchGlobalEvent(evt))
+      {
+        continue;
+      }
 
-    InputManager::onFrame();
+      // process app events at last
+      dispatchEvent(evt);
+    }
   }
 
-  virtual void onEvent(const SDL_Event& evt) override
+  void swapBuffer()
   {
-    auto e = m_zoomer.mapEvent(evt, DPI::ScaleFactor);
-    InputManager::onEvent(e);
+
+    auto profiler = CappingProfiler::getInstance();
+    // display fps
+    SDL_SetWindowTitle(m_sdlState.window, profiler->fpsStr());
+
+    // swap buffer at last
+    SDL_GL_SwapWindow(m_sdlState.window);
   }
 
-  virtual bool onGlobalEvent(const SDL_Event& evt) override
+  ~SDLRuntime()
   {
-    auto type = evt.type;
-
-    if (type == SDL_WINDOWEVENT)
+    if (m_inited && m_sdlState.glContext)
     {
-      if (evt.window.event == SDL_WINDOWEVENT_ENTER)
-      {
-        InputManager::setCursorVisibility(true);
-        return true;
-      }
-      else if (evt.window.event == SDL_WINDOWEVENT_LEAVE)
-      {
-        InputManager::setCursorVisibility(false);
-        return true;
-      }
+      // NOTE The failure to delete GL context may be related to multi-thread and is hard
+      // to make it right. For simplicity, we can just safely ignore the deletion.
+      //
+      // SDL_GL_DeleteContext(m_sdlState.glContext);
     }
-
-    auto& panning = m_zoomer.panning;
-    if (!panning && type == SDL_MOUSEBUTTONDOWN && (SDL_GetKeyboardState(nullptr)[SDL_SCANCODE_SPACE]))
+    if (m_inited && m_sdlState.window)
     {
-      panning = true;
-      InputManager::setMouseCursor(MouseEntity::CursorType::MOVE);
-      return true;
+      SDL_DestroyWindow(m_sdlState.window);
     }
-    else if (panning && type == SDL_MOUSEBUTTONUP)
-    {
-      panning = false;
-      InputManager::setMouseCursor(MouseEntity::CursorType::NORMAL);
-      return true;
-    }
-    else if (panning && type == SDL_MOUSEMOTION)
-    {
-      m_zoomer.offset.x += evt.motion.xrel / DPI::ScaleFactor;
-      m_zoomer.offset.y += evt.motion.yrel / DPI::ScaleFactor;
-      return true;
-    }
-    else if (type == SDL_MOUSEWHEEL && (SDL_GetModState() & KMOD_CTRL))
-    {
-      int mx, my;
-      SDL_GetMouseState(&mx, &my);
-      double dz = (evt.wheel.y > 0 ? 1.0 : -1.0) * 0.03;
-      double z2 = m_zoomer.zoom * (1 + dz);
-      if (z2 > 0.01 && z2 < 100)
-      {
-        m_zoomer.offset.x -= (mx / DPI::ScaleFactor - m_zoomer.offset.x) * dz;
-        m_zoomer.offset.y -= (my / DPI::ScaleFactor - m_zoomer.offset.y) * dz;
-        m_zoomer.zoom += m_zoomer.zoom * dz;
-        return true;
-      }
-      return false;
-    }
-    else if (type == SDL_KEYDOWN)
-    {
-      auto key = evt.key.keysym.sym;
-      auto mod = evt.key.keysym.mod;
-
-      if (key == SDLK_PAGEUP && (SDL_GetModState() & KMOD_CTRL))
-      {
-        FileManager::prevPage();
-        return true;
-      }
-
-      if (key == SDLK_PAGEDOWN && (SDL_GetModState() & KMOD_CTRL))
-      {
-        FileManager::nextPage();
-        return true;
-      }
-
-#ifndef EMSCRIPTEN
-      if ((mod & KMOD_CTRL) && key == SDLK_q)
-      {
-        m_shouldExit = true;
-        return true;
-      }
-#endif
-    }
-
-    return false;
+    SDL_Quit();
   }
 };
 
@@ -277,7 +318,7 @@ int main(int argc, char** argv)
     }
   }
 
-  Runtime* app = App::getInstance<Runtime>(1200, 800, "VGG");
+  SDLRuntime* app = App<SDLRuntime>::getInstance<SDLRuntime>(1200, 800, "VGG");
   ASSERT(app);
   if (auto fm = FileManager::getInstance(); fm && fm->fileCount() < 1)
   {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -23,7 +23,6 @@
 #include "Entity/InputManager.hpp"
 #include "Systems/RenderSystem.hpp"
 #include "Utils/App.hpp"
-#include "Utils/WindowTrait.hpp"
 #include "Utils/Utils.hpp"
 #include "Utils/Version.hpp"
 

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -23,6 +23,7 @@
 #include "Entity/InputManager.hpp"
 #include "Systems/RenderSystem.hpp"
 #include "Utils/App.hpp"
+#include "Utils/WindowTrait.hpp"
 #include "Utils/Utils.hpp"
 #include "Utils/Version.hpp"
 
@@ -38,35 +39,35 @@ class SDLRuntime : public App<SDLRuntime>
   SDLState m_sdlState;
   using Getter = std::function<std::any(void)>;
   using Setter = std::function<void(std::any)>;
-  std::unordered_map<std::string, std::pair<Getter, Setter>> m_prop;
+  std::unordered_map<std::string, std::pair<Getter, Setter>> m_properties;
 
   void initPropertyMap()
   {
-    m_prop["viewport_size"] = { [this]() -> std::any
-                                {
-                                  int dw, dh;
-                                  SDL_GL_GetDrawableSize(this->m_sdlState.window, &dw, &dh);
-                                  return std::any(std::pair<int, int>(dw, dh));
-                                },
-                                Setter() };
-    m_prop["window_size"] = { [this]()
-                              {
-                                int dw, dh;
-                                SDL_GetWindowSize(this->m_sdlState.window, &dw, &dh);
-                                return std::any(std::pair<int, int>(dw, dh));
-                              },
-                              [this](std::any size)
-                              {
-                                auto p = std::any_cast<std::pair<int, int>>(size);
-                                SDL_SetWindowSize(this->m_sdlState.window, p.first, p.second);
-                              } };
-    m_prop["app_size"] = { [this]() { return std::pair<int, int>(m_width, m_height); },
-                           [this](std::any size)
-                           {
-                             auto p = std::any_cast<std::pair<int, int>>(size);
-                             m_width = p.first;
-                             m_height = p.second;
-                           } };
+    m_properties["viewport_size"] = { [this]() -> std::any
+                                      {
+                                        int dw, dh;
+                                        SDL_GL_GetDrawableSize(this->m_sdlState.window, &dw, &dh);
+                                        return std::any(std::pair<int, int>(dw, dh));
+                                      },
+                                      Setter() };
+    m_properties["window_size"] = { [this]()
+                                    {
+                                      int dw, dh;
+                                      SDL_GetWindowSize(this->m_sdlState.window, &dw, &dh);
+                                      return std::any(std::pair<int, int>(dw, dh));
+                                    },
+                                    [this](std::any size)
+                                    {
+                                      auto p = std::any_cast<std::pair<int, int>>(size);
+                                      SDL_SetWindowSize(this->m_sdlState.window, p.first, p.second);
+                                    } };
+    m_properties["app_size"] = { [this]() { return std::pair<int, int>(m_width, m_height); },
+                                 [this](std::any size)
+                                 {
+                                   auto p = std::any_cast<std::pair<int, int>>(size);
+                                   m_width = p.first;
+                                   m_height = p.second;
+                                 } };
   }
 
 public:
@@ -211,8 +212,8 @@ public:
 
   std::any getProperty(const std::string& name)
   {
-    auto it = m_prop.find(name);
-    if (it != m_prop.end())
+    auto it = m_properties.find(name);
+    if (it != m_properties.end())
     {
       return (it->second.first)(); // getter
     }
@@ -221,8 +222,8 @@ public:
 
   void setProperty(const std::string& name, std::any value)
   {
-    auto it = m_prop.find(name);
-    if (it != m_prop.end())
+    auto it = m_properties.find(name);
+    if (it != m_properties.end())
     {
       (it->second.second)(value); // setter
     }

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -318,7 +318,7 @@ int main(int argc, char** argv)
     }
   }
 
-  SDLRuntime* app = App<SDLRuntime>::getInstance<SDLRuntime>(1200, 800, "VGG");
+  SDLRuntime* app = App<SDLRuntime>::getInstance(1200, 800, "VGG");
   ASSERT(app);
   if (auto fm = FileManager::getInstance(); fm && fm->fileCount() < 1)
   {

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -151,12 +151,11 @@ public:
 
     m_sdlState.glContext = glContext;
 
+    // switch to this context
     if (makeContextCurrent() == false)
     {
       return false;
     }
-
-    // switch to this context
     INFO("GL_VENDOR: %s", glGetString(GL_VENDOR));
     INFO("GL_RENDERER: %s", glGetString(GL_RENDERER));
     INFO("GL_VERSION: %s", glGetString(GL_VERSION));
@@ -171,12 +170,13 @@ public:
     m_properties["viewport_h"] = dh;
     m_properties["window_w"] = ww;
     m_properties["window_h"] = wh;
+    m_properties["app_w"] = w;
+    m_properties["app_h"] = h;
     return true;
   }
 
   bool makeContextCurrent()
   {
-    WARN("makeContextCurrent");
     if (SDL_GL_MakeCurrent(m_sdlState.window, m_sdlState.glContext) != 0)
     {
       handle_sdl_error();


### PR DESCRIPTION
1. replace unnecessary std::function by generic type.
2. Decouple app logic from SDL window framework(except for SDL_Event structure)

Details are included in commit and code comment.