### PR TITLE
Minor updates for skia and node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@
 compile_commands.json
 lib/node*
 lib/skia
-archive
+downloads

--- a/cmake/BuildLibnode.cmake
+++ b/cmake/BuildLibnode.cmake
@@ -6,12 +6,12 @@
     if(NOT NODE_LIBRARY_PATH)
       message("build libnode...")
       execute_process(
-        COMMAND ./configure --enable-static
+        COMMAND ./configure --enable-static --ninja
         WORKING_DIRECTORY ${WORK_DIR}
         COMMAND_ERROR_IS_FATAL ANY)
       execute_process(
-        COMMAND make -j16
-        WORKING_DIRECTORY ${WORK_DIR}
+        COMMAND ninja
+        WORKING_DIRECTORY "${WORK_DIR}/out/Release"
         COMMAND_ERROR_IS_FATAL ANY)
     endif()
 

--- a/cmake/ImportSkia.cmake
+++ b/cmake/ImportSkia.cmake
@@ -8,7 +8,7 @@ elseif(NOT IS_DIRECTORY ${SKIA_SOURCE_DIR})
   set(SKIA_ARCHIVE_TAG "20220914")
   set(SKIA_ARCHIVE_CHECKSUM "ed2005ca6e29a75309c922462127623e")
   set(SKIA_URL "https://github.com/verygoodgraphics/skia/releases/download/${SKIA_ARCHIVE_TAG}/skia-with-deps.tar.gz")
-  set(SKIA_ARCHIVE_LOCATION "${CMAKE_SOURCE_DIR}/archive/skia-with-deps.tar.gz")
+  set(SKIA_ARCHIVE_LOCATION "${CMAKE_SOURCE_DIR}/downloads/skia-with-deps-${SKIA_ARCHIVE_TAG}.tar.gz")
   file(DOWNLOAD ${SKIA_URL} ${SKIA_ARCHIVE_LOCATION}
     STATUS DOWNLOAD_STATUS
     SHOW_PROGRESS

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -25,7 +25,7 @@ if (NOT EMSCRIPTEN)
   if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${NODE_FOLDER}")
     set(NODE_VERSION "v18.15.0")
     set(DOWNLOAD_URL "https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}.tar.gz")
-    set(DOWNLOAD_AT_PATH "${CMAKE_CURRENT_SOURCE_DIR}/node.tar.gz")
+    set(DOWNLOAD_AT_PATH "${CMAKE_SOURCE_DIR}/downloads/node-${NODE_VERSION}.tar.gz")
 
     message(STATUS "Downloading ${DOWNLOAD_URL} to ${DOWNLOAD_AT_PATH}")
     file(DOWNLOAD
@@ -41,7 +41,7 @@ if (NOT EMSCRIPTEN)
     file(ARCHIVE_EXTRACT INPUT ${DOWNLOAD_AT_PATH}
       DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}")
     file(RENAME "${CMAKE_CURRENT_SOURCE_DIR}/node-${NODE_VERSION}" "${CMAKE_CURRENT_SOURCE_DIR}/${NODE_FOLDER}")
-    file(REMOVE ${DOWNLOAD_AT_PATH})
+    #file(REMOVE ${DOWNLOAD_AT_PATH})
   endif()
 
   add_library(vgg_libnode STATIC empty.cpp)
@@ -99,21 +99,21 @@ if (NOT EMSCRIPTEN)
     )
   else()
     target_link_directories(vgg_libnode PUBLIC
-      ${NODE_FOLDER}/out/Release/obj.target
-      ${NODE_FOLDER}/out/Release/obj.target/deps/base64
-      ${NODE_FOLDER}/out/Release/obj.target/deps/brotli
-      ${NODE_FOLDER}/out/Release/obj.target/deps/cares
-      ${NODE_FOLDER}/out/Release/obj.target/deps/histogram
-      ${NODE_FOLDER}/out/Release/obj.target/deps/llhttp
-      ${NODE_FOLDER}/out/Release/obj.target/deps/nghttp2
-      ${NODE_FOLDER}/out/Release/obj.target/deps/ngtcp2
-      ${NODE_FOLDER}/out/Release/obj.target/deps/openssl
-      ${NODE_FOLDER}/out/Release/obj.target/deps/simdutf
-      ${NODE_FOLDER}/out/Release/obj.target/deps/uv
-      ${NODE_FOLDER}/out/Release/obj.target/deps/uvwasi
-      ${NODE_FOLDER}/out/Release/obj.target/deps/zlib
-      ${NODE_FOLDER}/out/Release/obj.target/tools/icu
-      ${NODE_FOLDER}/out/Release/obj.target/tools/v8_gypfiles
+      ${NODE_FOLDER}/out/Release/obj
+      ${NODE_FOLDER}/out/Release/obj/deps/base64
+      ${NODE_FOLDER}/out/Release/obj/deps/brotli
+      ${NODE_FOLDER}/out/Release/obj/deps/cares
+      ${NODE_FOLDER}/out/Release/obj/deps/histogram
+      ${NODE_FOLDER}/out/Release/obj/deps/llhttp
+      ${NODE_FOLDER}/out/Release/obj/deps/nghttp2
+      ${NODE_FOLDER}/out/Release/obj/deps/ngtcp2
+      ${NODE_FOLDER}/out/Release/obj/deps/openssl
+      ${NODE_FOLDER}/out/Release/obj/deps/simdutf
+      ${NODE_FOLDER}/out/Release/obj/deps/uv
+      ${NODE_FOLDER}/out/Release/obj/deps/uvwasi
+      ${NODE_FOLDER}/out/Release/obj/deps/zlib
+      ${NODE_FOLDER}/out/Release/obj/tools/icu
+      ${NODE_FOLDER}/out/Release/obj/tools/v8_gypfiles
     )
     target_link_libraries(vgg_libnode PRIVATE
       "-Wl,--whole-archive"


### PR DESCRIPTION

### Explanation of Changes
- Keep skia and node downloaded files with version suffix in the same place with a new directory name called "downloads".
- Use ninja for node compiling, for better compiling progress display and auto parallelism . Already tested on Linux and macOS
