### PR TITLE
make sure to use clang in nix shell; using latest unstable nixpkgs to…

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -49,6 +49,10 @@ if (NOT EMSCRIPTEN)
   add_library(vgg_libnode_stub STATIC
     ${NODE_FOLDER}/src/node_snapshot_stub.cc)
 
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND "$ENV{name}" STREQUAL "nix-shell")
+    target_link_libraries(vgg_libnode_stub atomic)
+  endif()
+
   cmake_minimum_required(VERSION 3.22) # this is requied for the following invoking
   add_custom_command(TARGET vgg_libnode
     PRE_BUILD

--- a/shell.nix
+++ b/shell.nix
@@ -1,15 +1,16 @@
 # NOTE It is for linux deployment build only. Use it with `nix-shell --pure`
-# NOTE if you want to use vulkan driver, you must be in the "video" user group
-{ pkgs ? import (fetchTarball "https://s5.vgg.cool/nixos-23.05.tar.gz") {}
-, nixgl ? import (fetchTarball "https://github.com/guibou/nixGL/archive/master.tar.gz") {}
+# NOTE if you failed to run vulkan, please check you are in the "video" user group
+{ pkgs ? import (fetchTarball "https://github.com/verygoodgraphics/nixpkgs/archive/refs/tags/unstable-20230917.tar.gz") {}
+, nixgl ? import (fetchTarball "https://github.com/verygoodgraphics/nixGL/archive/master.tar.gz") {}
 , nvidiaGpu ? false
 }:
 with pkgs;
   mkShell {
     buildInputs = [
       # build tools
-      clang
+      clang_15
       cmake
+      cmakeCurses
       ninja
       python3
       glslang # or shaderc
@@ -33,4 +34,9 @@ with pkgs;
       nixgl.auto.nixVulkanNvidia
     ]
     ;
+
+    shellHook = ''
+      export CC=${clang_15}/bin/clang
+      export CXX=${clang_15}/bin/clang++
+    '';
   }


### PR DESCRIPTION
… prevent compiler bugs

### Description
The Clang compiler was not used even if it is installed in nix shell.

However, VGG runtime is not able to compile with Clang because node is unable to compile, which is due to incorrect compiler configuration https://github.com/NixOS/nixpkgs/issues/91285

We have to switch to unstable nixpkgs and add a special link target under nix + Clang environment for VGG runtime to compile successfully.

### Explanation of Changes
1. using this specific tag in our forked nixpkgs: https://github.com/verygoodgraphics/nixpkgs/releases/tag/unstable-20230917, which is the same version used for our forked nixGL
2. using Clang 15 explicitly and setting up the correct environment variables
3. added ccmake (cmakeCurses) for better cmake debugging inside nix shell
