### PR TITLE
Fix node building failure under macos

### DIFF
--- a/cmake/BuildLibnode.cmake
+++ b/cmake/BuildLibnode.cmake
@@ -5,10 +5,20 @@
 
     if(NOT NODE_LIBRARY_PATH)
       message("build libnode...")
+
+      # Configure
       execute_process(
         COMMAND ./configure --enable-static --ninja
         WORKING_DIRECTORY ${WORK_DIR}
         COMMAND_ERROR_IS_FATAL ANY)
+
+      # This is a patch if there is only python3 in search path, which is neccessary for building node with ninja
+      execute_process(
+        COMMAND sed -i".bak" "s/env python$/env python3/" tools/specialize_node_d.py
+        WORKING_DIRECTORY "${WORK_DIR}"
+        COMMAND_ERROR_IS_FATAL ANY)
+
+      # Build node with ninja
       execute_process(
         COMMAND ninja
         WORKING_DIRECTORY "${WORK_DIR}/out/Release"


### PR DESCRIPTION

### Description
This adds a (reentrant) patching process before compiling node with ninja in an environment without a unversioned python executable, which is common case for macos.


