### PR TITLE
improved node building script

### DIFF
--- a/cmake/BuildLibnode.cmake
+++ b/cmake/BuildLibnode.cmake
@@ -1,30 +1,31 @@
-  function(build_libnode WORK_DIR)
-    find_library(NODE_LIBRARY_PATH node
-      PATHS "${WORK_DIR}/out/Release"
-      NO_DEFAULT_PATH)
+function(build_libnode WORK_DIR)
 
-    if(NOT NODE_LIBRARY_PATH)
-      message("build libnode...")
+  execute_process(
+    COMMAND ninja -C "${WORK_DIR}/out/Release"
+    ERROR_VARIABLE IS_NOT_BUILDABLE
+  )
 
-      # Configure
-      execute_process(
-        COMMAND ./configure --enable-static --ninja
-        WORKING_DIRECTORY ${WORK_DIR}
-        COMMAND_ERROR_IS_FATAL ANY)
+  if (IS_NOT_BUILDABLE)
+    # Configure
+    execute_process(
+      COMMAND ./configure --enable-static --ninja
+      WORKING_DIRECTORY ${WORK_DIR}
+      COMMAND_ERROR_IS_FATAL ANY)
 
-      # This is a patch if there is only python3 in search path, which is neccessary for building node with ninja
-      execute_process(
-        COMMAND sed -i".bak" "s/env python$/env python3/" tools/specialize_node_d.py
-        WORKING_DIRECTORY "${WORK_DIR}"
-        COMMAND_ERROR_IS_FATAL ANY)
+    # This is a patch if there is only python3 in search path, which is neccessary for building node with ninja
+    execute_process(
+      COMMAND sed -i".bak" "s/env python$/env python3/" tools/specialize_node_d.py
+      WORKING_DIRECTORY "${WORK_DIR}"
+      COMMAND_ERROR_IS_FATAL ANY)
 
-      # Build node with ninja
-      execute_process(
-        COMMAND ninja
-        WORKING_DIRECTORY "${WORK_DIR}/out/Release"
-        COMMAND_ERROR_IS_FATAL ANY)
-    endif()
+    # Build node with ninja
+    execute_process(
+      COMMAND ninja -C "${WORK_DIR}/out/Release"
+      COMMAND_ERROR_IS_FATAL ANY)
+  else()
+    message(STATUS "Node already build.")
+  endif()
 
-  endfunction()
+endfunction()
 
-  build_libnode(${NODE_DIR})
+build_libnode(${NODE_DIR})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -45,30 +45,35 @@ if (NOT EMSCRIPTEN)
     #file(REMOVE ${DOWNLOAD_AT_PATH})
   endif()
 
-  add_library(vgg_libnode STATIC empty.cpp)
-  add_library(vgg_libnode_stub STATIC
-    ${NODE_FOLDER}/src/node_snapshot_stub.cc)
-
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND "$ENV{name}" STREQUAL "nix-shell")
-    target_link_libraries(vgg_libnode_stub atomic)
-  endif()
-
+  # this is a custom target to build node with its own building system
+  # NOTE this target will always be invoked
   cmake_minimum_required(VERSION 3.22) # this is requied for the following invoking
-  add_custom_command(TARGET vgg_libnode
-    PRE_BUILD
+  add_custom_target(vgg_libnode_building
+    COMMENT "Build node if neccessary..."
     COMMAND cmake -DNODE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/${NODE_FOLDER}
       -P ${CMAKE_CURRENT_SOURCE_DIR}/../cmake/BuildLibnode.cmake
-    COMMENT "Build libnode if needed"
   )
 
+  # this is an empty library for linking purpose only
+  add_library(vgg_libnode STATIC empty.cpp)
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND "$ENV{name}" STREQUAL "nix-shell")
+    target_link_libraries(vgg_libnode INTERFACE atomic)
+  endif()
   target_include_directories(vgg_libnode PUBLIC
     ${NODE_FOLDER}/src
     ${NODE_FOLDER}/deps/uv/include
     ${NODE_FOLDER}/deps/v8/include)
+  add_dependencies(vgg_libnode vgg_libnode_building)
+
+  # this is a stub library for providing missing interface that must be linked to libnode
+  add_library(vgg_libnode_stub STATIC
+    ${NODE_FOLDER}/src/node_snapshot_stub.cc
+  )
   target_include_directories(vgg_libnode_stub PUBLIC
     ${NODE_FOLDER}/src
     ${NODE_FOLDER}/deps/uv/include
     ${NODE_FOLDER}/deps/v8/include)
+
   if(APPLE)
     target_link_directories(vgg_libnode PUBLIC ${NODE_FOLDER}/out/Release)
     target_link_libraries(vgg_libnode PRIVATE


### PR DESCRIPTION
### Description

Currently, any changes in the node folder won't be automatically detected because the nodejs building is a custom command attached to `vgg_libnode` target and in most of the time this target is already built, thus the rebuilding in node folder won't be triggered.

### Explanation of Changes

1. In `cmake/BuildLibnode.cmake`, we changed to running a ninja test in the output folder to determine if we need re-configure and re-build of nodejs, instead of simply detecting a single `node` object.
2. In `lib/CMakeLists.txt`, we changed the node building invoking from custom command attached to `vgg_libnode` to an independent custom target which will always be invoked during the configure and building process.
3. Did some refactoring with comments added.
