### PR TITLE
Fixed skia building for wasm

### DIFF
--- a/cmake/ImportSkia.cmake
+++ b/cmake/ImportSkia.cmake
@@ -15,8 +15,8 @@ if(DEFINED SKIA_DIR)
 # case 2: no skia source code is prepared, so we download and uncompress it
 #
 elseif(NOT IS_DIRECTORY ${SKIA_SOURCE_DIR})
-  set(SKIA_ARCHIVE_TAG "20220914")
-  set(SKIA_ARCHIVE_MD5_CHECKSUM "ed2005ca6e29a75309c922462127623e")
+  set(SKIA_ARCHIVE_TAG "20230919")
+  set(SKIA_ARCHIVE_MD5_CHECKSUM "e8cc0ba3dd1c86545c369570340e8f04")
   set(SKIA_URL "https://github.com/verygoodgraphics/skia/releases/download/${SKIA_ARCHIVE_TAG}/skia-with-deps.tar.gz")
   set(SKIA_ARCHIVE_LOCATION "${CMAKE_SOURCE_DIR}/downloads/skia-with-deps-${SKIA_ARCHIVE_TAG}.tar.gz")
 
@@ -77,11 +77,6 @@ foreach(OPT ${PRINT_CONFIG_OPTIONS})
   message(STATUS ${OPT})
 endforeach(OPT)
 
-if(VGG_VAR_PLATFORM_TARGET STREQUAL "macOS-apple_silicon")
-  string(APPEND OPTIONS " target_cpu='arm64'")
-elseif(VGG_VAR_PLATFORM_TARGET STREQUAL "WASM")
-  string(APPEND OPTIONS " target_cpu='wasm'")
-endif()
 # config skia
 execute_process(COMMAND ${GN} gen ${SKIA_LIB_BUILD_PREFIX} ${CONFIG_OPTIONS}
 WORKING_DIRECTORY ${SKIA_EXTERNAL_PROJECT_DIR} COMMAND_ERROR_IS_FATAL ANY)

--- a/cmake/SkiaUtils.cmake
+++ b/cmake/SkiaUtils.cmake
@@ -105,8 +105,11 @@ skia_use_system_expat=false
 skia_use_expat=false
 skia_enable_pdf=false")
 
+if (EMSCRIPTEN)
+message(STATUS "EMSDK=$ENV{EMSDK}")
 set(SKIA_PRESET_FEATURES_FOR_WASM
-"skia_use_freetype=true
+"skia_emsdk_dir=\"$ENV{EMSDK}\"
+skia_use_freetype=true
 skia_enable_svg=true
 skia_use_zlib=true
 skia_use_system_zlib=false
@@ -131,6 +134,7 @@ skia_use_libheif=false
 skia_use_expat=false
 skia_use_vulkan=false
 skia_enable_pdf=false")
+endif()
 
 cmake_minimum_required(VERSION 3.19) # for string(JSON ...)
 
@@ -174,7 +178,7 @@ elseif(platform STREQUAL "macOS-apple_silicon")
   foreach(OPT ${SKIA_PRESET_FEATURES_FOR_MACOS})
     string(APPEND OPTIONS " ${OPT}")
   endforeach(OPT)
-elseif(platform STREQUAL "WASM")
+elseif(platform STREQUAL "WASM" AND DEFINED EMSCRIPTEN)
   string(APPEND OPTIONS " target_cpu=\"wasm\"")
   foreach(OPT ${SKIA_PRESET_FEATURES_FOR_WASM})
     string(APPEND OPTIONS " ${OPT}")
@@ -190,7 +194,7 @@ if(config STREQUAL "RelWithDebInfo")
 else()
   string(APPEND OPTIONS " extra_cflags_cc=[\"-fvisibility=default\", \"-frtti\"]")
 endif()
-elseif(platform STREQUAL "WASM")
+elseif(platform STREQUAL "WASM" AND DEFINED EMSCRIPTEN)
 string(APPEND OPTIONS " extra_cflags_cc=[\"-frtti\",\"-s\", \"-fvisibility=default\"] extra_cflags=[\"-Wno-unknown-warning-option\",\"-s\",\"-s\"]")
 endif()
 

--- a/src/Usecase/ModelChanged.cpp
+++ b/src/Usecase/ModelChanged.cpp
@@ -1,4 +1,4 @@
-#include "ModelChanged.hpp"
+#include "UseCase/ModelChanged.hpp"
 
 #include "Domain/Daruma.hpp"
 

--- a/src/Usecase/ResizeWindow.cpp
+++ b/src/Usecase/ResizeWindow.cpp
@@ -1,4 +1,4 @@
-#include "ResizeWindow.hpp"
+#include "UseCase/ResizeWindow.hpp"
 
 namespace VGG
 {


### PR DESCRIPTION
### Description
There is an internal emsdk installation in skia source code which will be mixed up with external emsdk used to compile VGG runtime, which caused skia fail to compile.

The other failing reason is the compiling of canvaskit module under wasm env in skia, which is not relevant to VGG.

### Explanation of Changes

1. Modify skia building cmake script to add external emsdk support.
2. Update our forked skia to disable canvaskit under wasm, and remove the unused emsdk binaries in release package to minimize skia package size. See https://github.com/verygoodgraphics/skia/commit/121767e06d3f452c54489f2576821eaaaf4a8360 and https://github.com/verygoodgraphics/skia/commit/66edb03d6362437179c8c1b6a592c5db180de343

Tested both on macOS and Linux with emsdk v3.1.46. Emsdk v3.1.17 still has a problem with preload files.
