### PR TITLE
Bugfix expanding symbol performance

### DIFF
--- a/include/Domain/Layout/ExpandSymbol.hpp
+++ b/include/Domain/Layout/ExpandSymbol.hpp
@@ -31,11 +31,22 @@ namespace Layout
 {
 constexpr auto K_SEPARATOR = "__";
 
+namespace Internal
+{
+namespace Rule
+{
+struct Rule;
+}
+} // namespace Internal
+
 class ExpandSymbol
 {
+  using RuleMap = std::unordered_map<std::string, std::shared_ptr<Internal::Rule::Rule>>;
+
   const nlohmann::json& m_designJson;
   const nlohmann::json& m_layoutJson;
   nlohmann::json m_outLayoutJson;
+  RuleMap m_layoutRulesCache;
   std::unordered_map<std::string, nlohmann::json> m_masters;
   std::unordered_map<std::string, nlohmann::json> m_layoutRules;
 
@@ -123,6 +134,8 @@ private:
                                    const std::vector<std::string>& instanceIdStack,
                                    const nlohmann::json& overrideItem);
   nlohmann::json* findLayoutObjectById(const std::string& id);
+
+  RuleMap getLayoutRules();
 };
 } // namespace Layout
 

--- a/include/Domain/Layout/ExpandSymbol.hpp
+++ b/include/Domain/Layout/ExpandSymbol.hpp
@@ -42,11 +42,12 @@ struct Rule;
 class ExpandSymbol
 {
   using RuleMap = std::unordered_map<std::string, std::shared_ptr<Internal::Rule::Rule>>;
+  using RuleMapPtr = std::shared_ptr<RuleMap>;
 
   const nlohmann::json& m_designJson;
   const nlohmann::json& m_layoutJson;
-  nlohmann::json m_outLayoutJson;
-  RuleMap m_layoutRulesCache;
+  std::unordered_map<std::string, nlohmann::json> m_outLayoutJsonMap; // performance
+  RuleMapPtr m_layoutRulesCache;                                      // performance
   std::unordered_map<std::string, nlohmann::json> m_masters;
   std::unordered_map<std::string, nlohmann::json> m_layoutRules;
 
@@ -130,12 +131,13 @@ private:
   void removeInvalidLayoutRule(const nlohmann::json& instanceChildren);
   bool hasOriginalLayoutRule(const std::string& id);
   bool hasRuntimeLayoutRule(const nlohmann::json& id);
-  nlohmann::json* findLayoutObject(nlohmann::json& instance,
-                                   const std::vector<std::string>& instanceIdStack,
-                                   const nlohmann::json& overrideItem);
-  nlohmann::json* findLayoutObjectById(const std::string& id);
+  nlohmann::json* findOutLayoutObject(nlohmann::json& instance,
+                                      const std::vector<std::string>& instanceIdStack,
+                                      const nlohmann::json& overrideItem);
+  nlohmann::json* findOutLayoutObjectById(const std::string& id);
 
-  RuleMap getLayoutRules();
+  RuleMapPtr getLayoutRules();
+  nlohmann::json generateOutLayoutJson();
 };
 } // namespace Layout
 

--- a/include/Domain/Layout/ExpandSymbol.hpp
+++ b/include/Domain/Layout/ExpandSymbol.hpp
@@ -73,7 +73,7 @@ private:
   void resizeInstance(nlohmann::json& instance, nlohmann::json& master);
 
   void layoutInstance(nlohmann::json& instance, const Size& instanceSize);
-  void overrideLayoutRuleSize(const std::string& instanceId, const Size& instanceSize);
+  void overrideLayoutRuleSize(const nlohmann::json& instanceId, const Size& instanceSize);
 
   void resizeSubtree(nlohmann::json& rootTreeJson,
                      nlohmann::json& subtreeJson,
@@ -85,7 +85,7 @@ private:
   void scalePoint(nlohmann::json& json, const char* key, float xScaleFactor, float yScaleFactor);
 
   void layoutSubtree(nlohmann::json& rootTreeJson,
-                     const std::string& subtreeNodeId,
+                     const nlohmann::json& subtreeNodeId,
                      const nlohmann::json& newBoundsJson);
   void layoutDirtyNodes(nlohmann::json& rootTreeJson);
 

--- a/include/Domain/Layout/Layout.hpp
+++ b/include/Domain/Layout/Layout.hpp
@@ -16,7 +16,6 @@
 #pragma once
 
 #include "Domain/Daruma.hpp"
-#include "ExpandSymbol.hpp"
 #include "Utility/Log.hpp"
 #include "Node.hpp"
 
@@ -40,10 +39,11 @@ struct Rule;
 
 class Layout
 {
+public:
   using RuleMap = std::unordered_map<std::string, std::shared_ptr<Internal::Rule::Rule>>;
 
+private:
   JsonDocumentPtr m_designDoc;
-  JsonDocumentPtr m_layoutDoc;
   std::shared_ptr<LayoutNode> m_layoutTree;
   RuleMap m_rules;
   bool m_isRootTree{ true }; // root document or fragment
@@ -51,6 +51,7 @@ class Layout
 
 public:
   Layout(JsonDocumentPtr designDoc, JsonDocumentPtr layoutDoc, bool isRootTree = true);
+  Layout(JsonDocumentPtr designDoc, RuleMap rules, bool isRootTree = true);
 
   void layout(Size size, bool updateRule = false);
   void resizeNodeThenLayout(const std::string& nodeId, Size size);
@@ -68,6 +69,9 @@ public:
 
   JsonDocumentPtr displayDesignDoc();
 
+public:
+  static RuleMap collectRules(const nlohmann::json& json);
+
 private:
   void buildLayoutTree();
   std::shared_ptr<LayoutNode> createOneLayoutNode(const nlohmann::json& j,
@@ -80,7 +84,6 @@ private:
   void createOneOrMoreLayoutNodes(const nlohmann::json& j,
                                   nlohmann::json::json_pointer currentPath,
                                   std::shared_ptr<LayoutNode> parent);
-  void collectRules(const nlohmann::json& json);
   void configureNodeAutoLayout(std::shared_ptr<LayoutNode> node);
 
   bool hasFirstOnTopNode();

--- a/include/Domain/Layout/Layout.hpp
+++ b/include/Domain/Layout/Layout.hpp
@@ -41,17 +41,18 @@ class Layout
 {
 public:
   using RuleMap = std::unordered_map<std::string, std::shared_ptr<Internal::Rule::Rule>>;
+  using RuleMapPtr = std::shared_ptr<RuleMap>;
 
 private:
   JsonDocumentPtr m_designDoc;
   std::shared_ptr<LayoutNode> m_layoutTree;
-  RuleMap m_rules;
+  RuleMapPtr m_rules;
   bool m_isRootTree{ true }; // root document or fragment
   std::vector<Size> m_pageSize;
 
 public:
   Layout(JsonDocumentPtr designDoc, JsonDocumentPtr layoutDoc, bool isRootTree = true);
-  Layout(JsonDocumentPtr designDoc, RuleMap rules, bool isRootTree = true);
+  Layout(JsonDocumentPtr designDoc, RuleMapPtr rules, bool isRootTree = true);
 
   void layout(Size size, bool updateRule = false);
   void resizeNodeThenLayout(const std::string& nodeId, Size size);
@@ -70,7 +71,7 @@ public:
   JsonDocumentPtr displayDesignDoc();
 
 public:
-  static RuleMap collectRules(const nlohmann::json& json);
+  static RuleMapPtr collectRules(const nlohmann::json& json);
 
 private:
   void buildLayoutTree();

--- a/src/Domain/Layout/ExpandSymbol.cpp
+++ b/src/Domain/Layout/ExpandSymbol.cpp
@@ -1010,7 +1010,8 @@ void ExpandSymbol::layoutInstance(nlohmann::json& instance, const Size& instance
   overrideLayoutRuleSize(instance[K_ID], instanceSize);
 }
 
-void ExpandSymbol::overrideLayoutRuleSize(const std::string& instanceId, const Size& instanceSize)
+void ExpandSymbol::overrideLayoutRuleSize(const nlohmann::json& instanceId,
+                                          const Size& instanceSize)
 {
   DEBUG("ExpandSymbol::overrideLayoutRuleSize, instanceId: %s, size: %f, %f",
         instanceId.c_str(),
@@ -1046,7 +1047,7 @@ void ExpandSymbol::overrideLayoutRuleSize(const std::string& instanceId, const S
 }
 
 void ExpandSymbol::layoutSubtree(nlohmann::json& rootTreeJson,
-                                 const std::string& subtreeNodeId,
+                                 const nlohmann::json& subtreeNodeId,
                                  const nlohmann::json& newBoundsJson)
 {
   Rect newBounds = newBoundsJson;
@@ -1205,10 +1206,7 @@ bool ExpandSymbol::hasOriginalLayoutRule(const std::string& id)
 
 bool ExpandSymbol::hasRuntimeLayoutRule(const nlohmann::json& id)
 {
-  auto& rules = m_outLayoutJson[K_OBJ];
-  return std::find_if(rules.begin(),
-                      rules.end(),
-                      [id](const nlohmann::json& item) { return item[K_ID] == id; }) != rules.end();
+  return m_layoutRulesCache.find(id) != m_layoutRulesCache.end();
 }
 
 ExpandSymbol::RuleMap ExpandSymbol::getLayoutRules()

--- a/src/Domain/Layout/Layout.cpp
+++ b/src/Domain/Layout/Layout.cpp
@@ -31,16 +31,22 @@ using namespace VGG;
 using namespace VGG::Layout::Internal::Rule;
 
 Layout::Layout::Layout(JsonDocumentPtr designDoc, JsonDocumentPtr layoutDoc, bool isRootTree)
+{
+  RuleMap rules;
+  if (layoutDoc)
+  {
+    rules = collectRules(layoutDoc->content());
+  }
+
+  new (this) Layout(designDoc, rules, isRootTree);
+}
+
+Layout::Layout::Layout(JsonDocumentPtr designDoc, RuleMap rules, bool isRootTree)
   : m_designDoc{ designDoc }
-  , m_layoutDoc{ layoutDoc }
+  , m_rules{ rules }
   , m_isRootTree{ isRootTree }
 {
   ASSERT(m_designDoc);
-
-  if (m_layoutDoc)
-  {
-    collectRules(m_layoutDoc->content());
-  }
 
   // initial config
   buildLayoutTree();
@@ -182,11 +188,13 @@ void Layout::Layout::createOneOrMoreLayoutNodes(const nlohmann::json& j,
   }
 }
 
-void Layout::Layout::collectRules(const nlohmann::json& json)
+Layout::Layout::RuleMap Layout::Layout::collectRules(const nlohmann::json& json)
 {
+  RuleMap result;
+
   if (!json.is_object())
   {
-    return;
+    return result;
   }
 
   auto& obj = json[K_OBJ];
@@ -203,9 +211,11 @@ void Layout::Layout::collectRules(const nlohmann::json& json)
       auto rule = std::make_shared<Internal::Rule::Rule>();
       *rule = item;
 
-      m_rules[id] = rule;
+      result[id] = rule;
     }
   }
+
+  return result;
 }
 
 void Layout::Layout::configureNodeAutoLayout(std::shared_ptr<LayoutNode> node)


### PR DESCRIPTION
### Description
Improve performance of extending symbol instances.
* Reduce the number of times layout json is converted to class objects
* Pass the shared pointer to the layout constructor
* Use unorded_map to optimize finding layout objects by id
