### PR TITLE
Bugfix wasm failing to run

### DIFF
--- a/src/Entry/WASM/CMakeLists.txt
+++ b/src/Entry/WASM/CMakeLists.txt
@@ -10,9 +10,9 @@ add_executable(vgg_runtime "main.cpp" "WasmBindings.cpp")
       -s USE_SDL=2 \
       -s NO_DISABLE_EXCEPTION_CATCHING \
       -s ASSERTIONS=1 \
-      -s INITIAL_MEMORY=1024MB \
+      -s INITIAL_MEMORY=64MB \
       -s ALLOW_MEMORY_GROWTH=1 \
-      -s STACK_SIZE=128MB \
+      -s STACK_SIZE=32MB \
       --no-heap-copy \
       -s EXPORTED_FUNCTIONS=\['_load_file_from_mem','_is_latest_version','_emscripten_main'\] \
       -s EXPORTED_RUNTIME_METHODS=\['ccall','cwrap','writeArrayToMemory','stringToUTF8'\] \

--- a/src/Entry/WASM/CMakeLists.txt
+++ b/src/Entry/WASM/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(vgg_runtime "main.cpp" "WasmBindings.cpp")
       -s USE_SDL=2 \
       -s NO_DISABLE_EXCEPTION_CATCHING \
       -s ASSERTIONS=1 \
-      -s INITIAL_MEMORY=64MB \
+      -s INITIAL_MEMORY=1024MB \
       -s ALLOW_MEMORY_GROWTH=1 \
       -s STACK_SIZE=32MB \
       --no-heap-copy \

--- a/src/Entry/WASM/CMakeLists.txt
+++ b/src/Entry/WASM/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(vgg_runtime "main.cpp" "WasmBindings.cpp")
       -s ASSERTIONS=1 \
       -s INITIAL_MEMORY=1024MB \
       -s ALLOW_MEMORY_GROWTH=1 \
-      -s STACK_SIZE=32MB \
+      -s STACK_SIZE=128MB \
       --no-heap-copy \
       -s EXPORTED_FUNCTIONS=\['_load_file_from_mem','_is_latest_version','_emscripten_main'\] \
       -s EXPORTED_RUNTIME_METHODS=\['ccall','cwrap','writeArrayToMemory','stringToUTF8'\] \

--- a/src/Entry/WASM/main.cpp
+++ b/src/Entry/WASM/main.cpp
@@ -58,7 +58,7 @@ extern "C"
     cfg.appName = "SdlRuntime";
     cfg.windowSize[0] = width;
     cfg.windowSize[1] = height;
-    cfg.graphicsContextConfig.multiSample = 4;
+    cfg.graphicsContextConfig.multiSample = 1;
     cfg.graphicsContextConfig.stencilBit = 8;
 
     auto app = application();


### PR DESCRIPTION
After increasing multiple samples for wasm, runtime is always failling to run. Increasing wasm initial memory and stack size won't solve this problem. Setting multiple sample to 1 finally works, but still has random crashes under firefox. Chrome works fine.