### PR TITLE
support detecting and updating skia directory

### DIFF
--- a/config/DepsConfig.json
+++ b/config/DepsConfig.json
@@ -1,7 +1,8 @@
 {
     "skia": {
-        "url": "https://github.com/verygoodgraphics/skia/releases/download/20231213/skia-with-deps.tar.gz",
-        "md5": "5fa2dae51fa00879187c8f37527666d5",
-        "filename":"skia-with-deps-20231213.tar.gz"
+        "url": "https://github.com/verygoodgraphics/skia/releases/download/20231214/skia-with-deps-20231214.tar.gz",
+        "md5": "1e6d53717c17c81397e1e2741b5bd341",
+        "filename":"skia-with-deps-20231214.tar.gz",
+        "commit": "1ab0b1d2242264a945c2c5ca45b8ec326e8946b7"
     }
 }


### PR DESCRIPTION
If skia got updated, the exisiting skia source dir won't be updated.

This PR adds an optional `commit` field in the DepsConfig.json, which tells cmake to detect skia source dir and update it if it is out of date.