### PR TITLE
fixed: Use page height as minimum layout height

### DIFF
--- a/src/Application/Controller.cpp
+++ b/src/Application/Controller.cpp
@@ -623,7 +623,8 @@ void Controller::aspectFill(int width)
 {
   auto         pageSize = m_layout->pageSize(m_presenter->currentPageIndex());
   auto         scaleFactor = width / pageSize.width;
-  Layout::Size size = { pageSize.width * scaleFactor, pageSize.height * scaleFactor };
+  Layout::Size size = { pageSize.width * scaleFactor,
+                        std::max(pageSize.height, pageSize.height * scaleFactor) };
   m_layout->layout(size);
 }
 


### PR DESCRIPTION
### Description
Fixed:
User can not scroll page to bottom in mobile browser.

### Explanation of Changes
Use page size as minimum layout height.