### PR TITLE
Bugfix layout empty flex container

### DIFF
--- a/include/Domain/Layout/Node.hpp
+++ b/include/Domain/Layout/Node.hpp
@@ -127,7 +127,11 @@ public:
 
   Layout::Rect frame() const;
   Layout::Rect bounds() const;
-  void setFrame(const Layout::Rect& newFrame, bool updateRule = false, bool useOldFrame = false);
+  void         setFrame(
+            const Layout::Rect& newFrame,
+            bool                updateRule = false,
+            bool                useOldFrame = false,
+            bool                duringLayout = false);
   void setViewModel(JsonDocumentPtr viewModel);
 
   void dump(std::string indent = {});

--- a/src/Domain/Layout/AutoLayout.hpp
+++ b/src/Domain/Layout/AutoLayout.hpp
@@ -52,7 +52,6 @@ private:
   std::shared_ptr<grid_item>                        m_gridItem;
   decltype(m_gridContainerPtr->calc_layout(-1, -1)) m_gridItemFrames;
 
-  bool m_isContainer{ false };
   Rect m_frame;
 
 public:
@@ -61,6 +60,7 @@ public:
 
 public:
   void configure();
+  void configureFlexContainer();
   void configureFlexItemMargin();
   void applyLayout(bool preservingOrigin);
   void setFrame(Rect frame);
@@ -78,15 +78,13 @@ public:
   {
     return !rule.expired();
   }
-  bool isContainer()
-  {
-    return m_isContainer;
-  }
+  bool isContainer();
   bool isFlexOrGridItem();
 
+  flexbox_node* getOrCreateFlexContainer();
   flexbox_node* getFlexContainer()
   {
-    return getFlexNode();
+    return isFlexContainer() ? getFlexNode() : nullptr;
   }
 
   std::unique_ptr<flexbox_node>& takeFlexItem()
@@ -116,7 +114,7 @@ public:
 
 private:
   Size calculateLayout(Size size);
-  void configureFlexNodeSize(flexbox_node* node);
+  void configureFlexNodeSize(flexbox_node* node, bool forContainer = false);
   void configureGridItemSize();
 
   flexbox_node* createFlexContainer();
@@ -139,7 +137,12 @@ private:
   bool isFirstChild();
   bool isLastChild();
 
-  void configureGridContainer(Rule::GridLayout* layout);
+  bool isFlexContainer();
+  bool isGridContainer();
+
+  Rule::GridLayout* gridLayout();
+
+  void configureGridContainer();
   void configureGridItem(Rule::GridItem* layout);
 
   void resetGridContainer();

--- a/src/Domain/Layout/Node.cpp
+++ b/src/Domain/Layout/Node.cpp
@@ -33,6 +33,10 @@
 #undef DEBUG
 #define DEBUG(msg, ...)
 
+#define VERBOSE DEBUG
+#undef VERBOSE
+#define VERBOSE(msg, ...)
+
 namespace
 {
 enum class EBooleanOperation
@@ -109,6 +113,7 @@ std::shared_ptr<Layout::Internal::AutoLayout> LayoutNode::containerAutoLayout()
 
 void LayoutNode::setNeedLayout()
 {
+  VERBOSE("LayoutNode::setNeedLayout: node: %s, %s", id().c_str(), path().c_str());
   m_needsLayout = true;
 }
 
@@ -146,7 +151,11 @@ Layout::Rect LayoutNode::frame() const
   return { origin(), size() };
 }
 
-void LayoutNode::setFrame(const Layout::Rect& newFrame, bool updateRule, bool useOldFrame)
+void LayoutNode::setFrame(
+  const Layout::Rect& newFrame,
+  bool                updateRule,
+  bool                useOldFrame,
+  bool                duringLayout)
 {
   saveChildrendOldFrame(); // save first, before all return
 
@@ -201,7 +210,10 @@ void LayoutNode::setFrame(const Layout::Rect& newFrame, bool updateRule, bool us
     if (m_autoLayout->isContainer())
     {
       resizeChildNodes(oldSize, newSize, true); // resize absolute child
-      setNeedLayout();
+      if (!duringLayout)
+      {
+        setNeedLayout();
+      }
       return;
     }
   }

--- a/test/domain/layout/layout_tests.cpp
+++ b/test/domain/layout/layout_tests.cpp
@@ -219,3 +219,17 @@ TEST_F(VggLayoutTestSuite, UpdateFlexContainerWidthByConstraints)
 
   EXPECT_TRUE(descendantFrame({ 0 }, 0) == expectedFrames[0]);
 }
+
+TEST_F(VggLayoutTestSuite, EmptyContainer)
+{
+  // Given
+  setupWithExpanding("testDataDir/layout/205_empty_container/");
+
+  // When
+  layout(*m_sut, Layout::Size{ 1920, 1080 });
+
+  // Then
+  std::vector<Layout::Rect> expectedFrames{ { { 26, 0 }, { 6, 6 } } };
+
+  EXPECT_TRUE(descendantFrame({ 1 }, 0) == expectedFrames[0]);
+}

--- a/test/testDataDir/layout/205_empty_container/design.json
+++ b/test/testDataDir/layout/205_empty_container/design.json
@@ -1,0 +1,595 @@
+{
+  "version": "1",
+  "fileType": 3,
+  "fileName": "/Users/houguanhua/code/vgg/vgg_runtime_C/test/testDataDir/layout/205_empty_container/bug-layout-empty-container.fig",
+  "frames": [
+    {
+      "id": "1:4",
+      "name": "Structure/Step Bars",
+      "isLocked": false,
+      "visible": true,
+      "contextSettings": {
+        "class": "graphicsContextSettings",
+        "blendMode": 27,
+        "opacity": 1.0,
+        "isolateBlending": false,
+        "transparencyKnockoutGroup": 0
+      },
+      "matrix": [
+        1.0,
+        0.0,
+        0.0,
+        1.0,
+        -21.0,
+        3.0
+      ],
+      "bounds": {
+        "class": "rect",
+        "constrainProportions": false,
+        "width": 43.0,
+        "height": 6.0,
+        "x": 0,
+        "y": 0
+      },
+      "transformedBounds": {
+        "class": "rect",
+        "constrainProportions": false,
+        "width": 43.0,
+        "height": 6.0,
+        "x": -21.0,
+        "y": 3.0
+      },
+      "style": {
+        "class": "style",
+        "borders": [],
+        "fills": [],
+        "blurs": [],
+        "shadows": []
+      },
+      "alphaMaskBy": [],
+      "outlineMaskBy": [],
+      "maskType": 0,
+      "styleEffectMaskArea": 2,
+      "maskShowType": 2,
+      "overflow": 2,
+      "styleEffectBoolean": 1,
+      "cornerSmoothing": 0.0,
+      "horizontalConstraint": 1,
+      "verticalConstraint": 1,
+      "resizesContent": 0,
+      "variableDefs": [],
+      "variableRefs": [],
+      "class": "frame",
+      "childObjects": [
+        {
+          "id": "1:5",
+          "name": "Step Bubbles",
+          "isLocked": false,
+          "visible": true,
+          "contextSettings": {
+            "class": "graphicsContextSettings",
+            "blendMode": 27,
+            "opacity": 1.0,
+            "isolateBlending": false,
+            "transparencyKnockoutGroup": 0
+          },
+          "matrix": [
+            1.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0
+          ],
+          "bounds": {
+            "class": "rect",
+            "constrainProportions": false,
+            "width": 22.0,
+            "height": 6.0,
+            "x": 0,
+            "y": 0
+          },
+          "transformedBounds": {
+            "class": "rect",
+            "constrainProportions": false,
+            "width": 22.0,
+            "height": 6.0,
+            "x": 0.0,
+            "y": 0.0
+          },
+          "style": {
+            "class": "style",
+            "borders": [],
+            "fills": [
+              {
+                "fillType": 0,
+                "color": {
+                  "class": "color",
+                  "red": 1.0,
+                  "green": 0.7742539048194885,
+                  "blue": 0.2592225670814514,
+                  "alpha": 1.0
+                },
+                "class": "fill",
+                "isEnabled": true,
+                "contextSettings": {
+                  "class": "graphicsContextSettings",
+                  "blendMode": 0,
+                  "opacity": 1.0,
+                  "isolateBlending": false,
+                  "transparencyKnockoutGroup": 0
+                }
+              }
+            ],
+            "blurs": [],
+            "shadows": []
+          },
+          "alphaMaskBy": [],
+          "outlineMaskBy": [],
+          "maskType": 0,
+          "styleEffectMaskArea": 2,
+          "maskShowType": 2,
+          "overflow": 1,
+          "styleEffectBoolean": 1,
+          "cornerSmoothing": 0.0,
+          "horizontalConstraint": 1,
+          "verticalConstraint": 1,
+          "resizesContent": 0,
+          "variableDefs": [],
+          "variableRefs": [],
+          "class": "path",
+          "shape": {
+            "class": "shape",
+            "subshapes": [
+              {
+                "class": "subshape",
+                "subGeometry": {
+                  "class": "rectangle",
+                  "radius": [
+                    6.0,
+                    6.0,
+                    6.0,
+                    6.0
+                  ]
+                },
+                "booleanOperation": 4
+              }
+            ],
+            "windingRule": 0
+          }
+        },
+        {
+          "id": "1:6",
+          "name": "d1, Step Bubbles",
+          "isLocked": false,
+          "visible": true,
+          "contextSettings": {
+            "class": "graphicsContextSettings",
+            "blendMode": 27,
+            "opacity": 1.0,
+            "isolateBlending": false,
+            "transparencyKnockoutGroup": 0
+          },
+          "matrix": [
+            1.0,
+            0.0,
+            0.0,
+            1.0,
+            26.0,
+            0.0
+          ],
+          "bounds": {
+            "class": "rect",
+            "constrainProportions": false,
+            "width": 6.0,
+            "height": 6.0,
+            "x": 0,
+            "y": 0
+          },
+          "transformedBounds": {
+            "class": "rect",
+            "constrainProportions": false,
+            "width": 6.0,
+            "height": 6.0,
+            "x": 26.0,
+            "y": 0.0
+          },
+          "style": {
+            "class": "style",
+            "borders": [],
+            "fills": [
+              {
+                "fillType": 0,
+                "color": {
+                  "class": "color",
+                  "red": 0.3764705955982208,
+                  "green": 0.40784314274787903,
+                  "blue": 0.45098039507865906,
+                  "alpha": 1.0
+                },
+                "class": "fill",
+                "isEnabled": true,
+                "contextSettings": {
+                  "class": "graphicsContextSettings",
+                  "blendMode": 0,
+                  "opacity": 1.0,
+                  "isolateBlending": false,
+                  "transparencyKnockoutGroup": 0
+                }
+              }
+            ],
+            "blurs": [],
+            "shadows": []
+          },
+          "alphaMaskBy": [],
+          "outlineMaskBy": [],
+          "maskType": 0,
+          "styleEffectMaskArea": 2,
+          "maskShowType": 2,
+          "overflow": 2,
+          "styleEffectBoolean": 1,
+          "cornerSmoothing": 0.0,
+          "horizontalConstraint": 1,
+          "verticalConstraint": 1,
+          "resizesContent": 0,
+          "variableDefs": [],
+          "variableRefs": [],
+          "class": "frame",
+          "childObjects": [],
+          "radius": [
+            6.0,
+            6.0,
+            6.0,
+            6.0
+          ]
+        },
+        {
+          "id": "1:7",
+          "name": "d2, Step Bubbles",
+          "isLocked": false,
+          "visible": true,
+          "contextSettings": {
+            "class": "graphicsContextSettings",
+            "blendMode": 27,
+            "opacity": 1.0,
+            "isolateBlending": false,
+            "transparencyKnockoutGroup": 0
+          },
+          "matrix": [
+            1.0,
+            0.0,
+            0.0,
+            1.0,
+            36.0,
+            0.0
+          ],
+          "bounds": {
+            "class": "rect",
+            "constrainProportions": false,
+            "width": 6.0,
+            "height": 6.0,
+            "x": 0,
+            "y": 0
+          },
+          "transformedBounds": {
+            "class": "rect",
+            "constrainProportions": false,
+            "width": 6.0,
+            "height": 6.0,
+            "x": 36.0,
+            "y": 0.0
+          },
+          "style": {
+            "class": "style",
+            "borders": [],
+            "fills": [
+              {
+                "fillType": 0,
+                "color": {
+                  "class": "color",
+                  "red": 0.3764705955982208,
+                  "green": 0.40784314274787903,
+                  "blue": 0.45098039507865906,
+                  "alpha": 1.0
+                },
+                "class": "fill",
+                "isEnabled": true,
+                "contextSettings": {
+                  "class": "graphicsContextSettings",
+                  "blendMode": 0,
+                  "opacity": 1.0,
+                  "isolateBlending": false,
+                  "transparencyKnockoutGroup": 0
+                }
+              }
+            ],
+            "blurs": [],
+            "shadows": []
+          },
+          "alphaMaskBy": [],
+          "outlineMaskBy": [],
+          "maskType": 0,
+          "styleEffectMaskArea": 2,
+          "maskShowType": 2,
+          "overflow": 2,
+          "styleEffectBoolean": 1,
+          "cornerSmoothing": 0.0,
+          "horizontalConstraint": 1,
+          "verticalConstraint": 1,
+          "resizesContent": 0,
+          "variableDefs": [],
+          "variableRefs": [],
+          "class": "frame",
+          "childObjects": [],
+          "radius": [
+            6.0,
+            6.0,
+            6.0,
+            6.0
+          ]
+        }
+      ],
+      "radius": [
+        0.0,
+        0.0,
+        0.0,
+        0.0
+      ],
+      "backgroundColor": {
+        "class": "color",
+        "red": 0.9607843160629272,
+        "green": 0.9607843160629272,
+        "blue": 0.9607843160629272,
+        "alpha": 1.0
+      }
+    },
+    {
+      "id": "0:2 default-frame",
+      "name": "Internal Only Canvas default-frame",
+      "isLocked": false,
+      "visible": false,
+      "contextSettings": {
+        "class": "graphicsContextSettings",
+        "blendMode": 27,
+        "opacity": 1.0,
+        "isolateBlending": false,
+        "transparencyKnockoutGroup": 0
+      },
+      "matrix": [
+        1,
+        0,
+        0,
+        1,
+        0,
+        0
+      ],
+      "bounds": {
+        "class": "rect",
+        "constrainProportions": false,
+        "width": 100.0,
+        "height": 100.0,
+        "x": 0.0,
+        "y": 0.0
+      },
+      "transformedBounds": {
+        "class": "rect",
+        "constrainProportions": false,
+        "width": 100.0,
+        "height": 100.0,
+        "x": 0.0,
+        "y": 0.0
+      },
+      "style": {
+        "class": "style",
+        "borders": [],
+        "fills": [],
+        "blurs": [],
+        "shadows": []
+      },
+      "alphaMaskBy": [],
+      "outlineMaskBy": [],
+      "maskType": 0,
+      "styleEffectMaskArea": 2,
+      "maskShowType": 2,
+      "overflow": 2,
+      "styleEffectBoolean": 1,
+      "class": "frame",
+      "childObjects": [
+        {
+          "id": "1:2",
+          "name": "Yellow/Yellow 500",
+          "isLocked": true,
+          "visible": false,
+          "contextSettings": {
+            "class": "graphicsContextSettings",
+            "blendMode": 27,
+            "opacity": 1.0,
+            "isolateBlending": false,
+            "transparencyKnockoutGroup": 0
+          },
+          "matrix": [
+            1.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0
+          ],
+          "bounds": {
+            "class": "rect",
+            "constrainProportions": false,
+            "width": 100.0,
+            "height": 100.0,
+            "x": 0,
+            "y": 0
+          },
+          "transformedBounds": {
+            "class": "rect",
+            "constrainProportions": false,
+            "width": 100.0,
+            "height": 100.0,
+            "x": 0.0,
+            "y": 0.0
+          },
+          "style": {
+            "class": "style",
+            "borders": [],
+            "fills": [
+              {
+                "fillType": 0,
+                "color": {
+                  "class": "color",
+                  "red": 1.0,
+                  "green": 0.7742539048194885,
+                  "blue": 0.2592225670814514,
+                  "alpha": 1.0
+                },
+                "class": "fill",
+                "isEnabled": true,
+                "contextSettings": {
+                  "class": "graphicsContextSettings",
+                  "blendMode": 0,
+                  "opacity": 1.0,
+                  "isolateBlending": false,
+                  "transparencyKnockoutGroup": 0
+                }
+              }
+            ],
+            "blurs": [],
+            "shadows": []
+          },
+          "alphaMaskBy": [],
+          "outlineMaskBy": [],
+          "maskType": 0,
+          "styleEffectMaskArea": 2,
+          "maskShowType": 2,
+          "overflow": 1,
+          "styleEffectBoolean": 1,
+          "cornerSmoothing": 0.0,
+          "horizontalConstraint": 1,
+          "verticalConstraint": 1,
+          "resizesContent": 0,
+          "variableDefs": [],
+          "variableRefs": [],
+          "class": "path",
+          "shape": {
+            "class": "shape",
+            "subshapes": [
+              {
+                "class": "subshape",
+                "subGeometry": {
+                  "class": "rectangle",
+                  "radius": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ]
+                },
+                "booleanOperation": 4
+              }
+            ],
+            "windingRule": 0
+          }
+        },
+        {
+          "id": "1:3",
+          "name": "Grey/Grey 700",
+          "isLocked": true,
+          "visible": false,
+          "contextSettings": {
+            "class": "graphicsContextSettings",
+            "blendMode": 27,
+            "opacity": 1.0,
+            "isolateBlending": false,
+            "transparencyKnockoutGroup": 0
+          },
+          "matrix": [
+            1.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            0.0
+          ],
+          "bounds": {
+            "class": "rect",
+            "constrainProportions": false,
+            "width": 100.0,
+            "height": 100.0,
+            "x": 0,
+            "y": 0
+          },
+          "transformedBounds": {
+            "class": "rect",
+            "constrainProportions": false,
+            "width": 100.0,
+            "height": 100.0,
+            "x": 0.0,
+            "y": 0.0
+          },
+          "style": {
+            "class": "style",
+            "borders": [],
+            "fills": [
+              {
+                "fillType": 0,
+                "color": {
+                  "class": "color",
+                  "red": 0.3764705955982208,
+                  "green": 0.40784314274787903,
+                  "blue": 0.45098039507865906,
+                  "alpha": 1.0
+                },
+                "class": "fill",
+                "isEnabled": true,
+                "contextSettings": {
+                  "class": "graphicsContextSettings",
+                  "blendMode": 0,
+                  "opacity": 1.0,
+                  "isolateBlending": false,
+                  "transparencyKnockoutGroup": 0
+                }
+              }
+            ],
+            "blurs": [],
+            "shadows": []
+          },
+          "alphaMaskBy": [],
+          "outlineMaskBy": [],
+          "maskType": 0,
+          "styleEffectMaskArea": 2,
+          "maskShowType": 2,
+          "overflow": 1,
+          "styleEffectBoolean": 1,
+          "cornerSmoothing": 0.0,
+          "horizontalConstraint": 1,
+          "verticalConstraint": 1,
+          "resizesContent": 0,
+          "variableDefs": [],
+          "variableRefs": [],
+          "class": "path",
+          "shape": {
+            "class": "shape",
+            "subshapes": [
+              {
+                "class": "subshape",
+                "subGeometry": {
+                  "class": "rectangle",
+                  "radius": [
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0
+                  ]
+                },
+                "booleanOperation": 4
+              }
+            ],
+            "windingRule": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/test/testDataDir/layout/205_empty_container/layout.json
+++ b/test/testDataDir/layout/205_empty_container/layout.json
@@ -1,0 +1,159 @@
+{
+  "obj": [
+    {
+      "class": "object",
+      "id": "1:6",
+      "width": {
+        "class": "width",
+        "value": {
+          "class": "length",
+          "value": 0,
+          "types": 4
+        }
+      },
+      "height": {
+        "class": "height",
+        "value": {
+          "class": "length",
+          "value": 6.0,
+          "types": 1
+        }
+      },
+      "layout": {
+        "class": "flexboxLayout",
+        "direction": 2,
+        "justifyContent": 1,
+        "alignItems": 1,
+        "alignContent": 1,
+        "wrap": 1,
+        "rowGap": 10.0,
+        "columnGap": 0,
+        "padding": [
+          10.0,
+          10.0,
+          10.0,
+          10.0
+        ],
+        "zOrder": false
+      },
+      "itemInLayout": {
+        "class": "flexboxItem",
+        "position": {
+          "class": "position",
+          "value": 1
+        },
+        "flexBasis": 0.0
+      }
+    },
+    {
+      "class": "object",
+      "id": "1:7",
+      "width": {
+        "class": "width",
+        "value": {
+          "class": "length",
+          "value": 0,
+          "types": 4
+        }
+      },
+      "height": {
+        "class": "height",
+        "value": {
+          "class": "length",
+          "value": 6.0,
+          "types": 1
+        }
+      },
+      "layout": {
+        "class": "flexboxLayout",
+        "direction": 2,
+        "justifyContent": 1,
+        "alignItems": 1,
+        "alignContent": 1,
+        "wrap": 1,
+        "rowGap": 10.0,
+        "columnGap": 0,
+        "padding": [
+          10.0,
+          10.0,
+          10.0,
+          10.0
+        ],
+        "zOrder": false
+      },
+      "itemInLayout": {
+        "class": "flexboxItem",
+        "position": {
+          "class": "position",
+          "value": 1
+        },
+        "flexBasis": 0.0
+      }
+    },
+    {
+      "class": "object",
+      "id": "1:4",
+      "width": {
+        "class": "width",
+        "value": {
+          "class": "length",
+          "value": 43.0,
+          "types": 1
+        }
+      },
+      "height": {
+        "class": "height",
+        "value": {
+          "class": "length",
+          "value": 0,
+          "types": 4
+        }
+      },
+      "layout": {
+        "class": "flexboxLayout",
+        "direction": 1,
+        "justifyContent": 1,
+        "alignItems": 1,
+        "alignContent": 1,
+        "wrap": 1,
+        "rowGap": 0,
+        "columnGap": 4.0,
+        "padding": [
+          0,
+          0,
+          0,
+          0
+        ],
+        "zOrder": false
+      }
+    },
+    {
+      "class": "object",
+      "id": "1:5",
+      "width": {
+        "class": "width",
+        "value": {
+          "class": "length",
+          "value": 22.0,
+          "types": 1
+        }
+      },
+      "height": {
+        "class": "height",
+        "value": {
+          "class": "length",
+          "value": 6.0,
+          "types": 1
+        }
+      },
+      "itemInLayout": {
+        "class": "flexboxItem",
+        "position": {
+          "class": "position",
+          "value": 1
+        },
+        "flexBasis": 0.0
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Description
Fixed:
* Layout empty flex container

### Explanation of Changes
Ignore layout rules for empty containers, such as padding, and use their original size.