### PR TITLE
optimized layout strategy for page aspect fill

### DIFF
--- a/include/Application/Controller.hpp
+++ b/include/Application/Controller.hpp
@@ -136,7 +136,7 @@ private:
   void fitPageForEditing();
 
   void scaleContent(Layout::Size size);
-  void aspectFill(int width);
+  void aspectFill(Layout::Size size);
   void aspectFit(Layout::Size size);
 
   std::shared_ptr<ViewModel> generateViewModel(std::shared_ptr<Daruma> model, Layout::Size size);

--- a/src/Application/Controller.cpp
+++ b/src/Application/Controller.cpp
@@ -647,17 +647,29 @@ void Controller::scaleContent(Layout::Size size)
     return;
   }
 
-  aspectFill(size.width);
+  aspectFill(size);
   // aspectFit(size);
 }
 
-void Controller::aspectFill(int width)
+void Controller::aspectFill(Layout::Size size)
 {
-  auto         pageSize = m_layout->pageSize(m_presenter->currentPageIndex());
-  auto         scaleFactor = width / pageSize.width;
-  Layout::Size size = { pageSize.width * scaleFactor,
-                        std::max(pageSize.height, pageSize.height * scaleFactor) };
-  m_layout->layout(size);
+  auto pageSize = m_layout->pageSize(m_presenter->currentPageIndex());
+  auto scaleFactor = size.width / pageSize.width;
+
+  if (scaleFactor < 1.)
+  {
+    Layout::Size targetSize = { pageSize.width * scaleFactor,
+                                pageSize.height }; // make sure to see all the contents
+    m_layout->layout(targetSize);
+  }
+  else
+  {
+    Layout::Size targetSize = {
+      pageSize.width * scaleFactor,
+      std::min(pageSize.height + size.height / 3., pageSize.height * scaleFactor) // set max height limit
+    };
+    m_layout->layout(targetSize);
+  }
 }
 
 void Controller::aspectFit(Layout::Size size)


### PR DESCRIPTION
Current aspect fill strategy only considers page width, which doesn't apply for some cases. This fixing consider both horizontal scale ratio and page height, to make sure the target layout height is not too small or too big.
