### PR TITLE
fixed unable to resize node in edit mode

### DIFF
--- a/src/Application/UIView.cpp
+++ b/src/Application/UIView.cpp
@@ -428,7 +428,7 @@ bool UIView::handleMouseEvent(
       break;
   }
 
-  fireMouseEvent(target, type, jsButtonIndex, x, y, motionX, motionY);
+  fireMouseEvent(target, type, jsButtonIndex, pointToPage.x, pointToPage.y, motionX, motionY);
   return true;
 }
 


### PR DESCRIPTION
### Description
Fixed:
* Unable to resize node in edit mode.

### Explanation of Changes
* Use correct mouse event location.