### PR TITLE
Fixed build error with gcc12 using c++20

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3")
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-unknown-warning-option -Wno-deprecated-declarations -Wno-nonnull -Wno-unused-private-field -Wno-maybe-uninitialized")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-unknown-warning-option -Wno-deprecated-declarations -Wno-nonnull -Wno-unused-private-field -Wno-maybe-uninitialized -Wno-error=restrict")
 endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
### Description
Fixed build error with gcc12 using c++20.

Because we use `-Werror` to treat all warnings as errors, we need further to use `-Wno-error=restrict` to treat all `restrict` errors back to warnings. If we only use `-Wno-restrict`, all the `restrict` warnings will be suppressed and it does not meet our expectation.