### PR TITLE
fixed: When making snapshot images, the size should be multiplied by …

### DIFF
--- a/src/Application/UIApplication.cpp
+++ b/src/Application/UIApplication.cpp
@@ -159,8 +159,9 @@ std::vector<uint8_t> UIApplication::makeImageSnapshot(layer::ImageOptions option
   ASSERT(m_layer);
   options.position[0] = 0;
   options.position[1] = 0;
-  options.extend[0] = m_view->contentSize().width;
-  options.extend[1] = m_view->contentSize().height;
+  const auto dpi = m_layer->context()->property().dpiScaling;
+  options.extend[0] = m_view->contentSize().width * dpi;
+  options.extend[1] = m_view->contentSize().height * dpi;
   if (auto maybeImageBytes = m_layer->makeImageSnapshot(options))
   {
     auto& bytes = maybeImageBytes.value();


### PR DESCRIPTION
### Description
Bugfix:
When making snapshot images, the size should be multiplied by dpi scale.