### PR TITLE
fixed: handle empty contour points

### DIFF
--- a/src/Domain/Layout/Node.cpp
+++ b/src/Domain/Layout/Node.cpp
@@ -1252,6 +1252,11 @@ Layout::Rect LayoutNode::resizeContour(
   // get model point
   const bool                       isClosed = pModel->closed;
   std::vector<Layout::BezierPoint> oldModelPoints = contourElement.points();
+  if (oldModelPoints.empty())
+  {
+    WARN("LayoutNode::resizeContour: empty points");
+    return {};
+  }
 
   // multiply matrix, to layout point
   const auto                       oldModelMatrix = modelMatrix();

--- a/src/Domain/Layout/Rect.cpp
+++ b/src/Domain/Layout/Rect.cpp
@@ -145,10 +145,9 @@ Rect Rect::makeFromPoints(const std::vector<Point>& points)
 
 Rect Rect::makeFromPoints(const std::vector<BezierPoint>& points, bool isClosed)
 {
-  ASSERT(points.size() > 1);
-
   if (points.empty())
   {
+    WARN("Rect::makeFromPoints: empty points");
     return {};
   }
 


### PR DESCRIPTION
### Description
Fixed:
Crash when resizing contour with zero points.