### PR TITLE
Bugfix pan gesture zero translation and velocity

### DIFF
--- a/include/Application/Event/Event.hpp
+++ b/include/Application/Event/Event.hpp
@@ -229,10 +229,10 @@ struct VMouseWheelEvent
 struct VTouchEvent
 {
   uint32_t type;
-  int32_t  windowX; /**< X coordinate, relative to window */
-  int32_t  windowY; /**< Y coordinate, relative to window */
-  float    xrel;    /**< The relative motion in the X direction */
-  float    yrel;    /**< The relative motion in the Y direction */
+  float    windowX; /**< X coordinate, relative to window. Normalized in the range 0...1 */
+  float    windowY; /**< Y coordinate, relative to window. Normalized in the range 0...1 */
+  float    xrel;    /**< The relative motion in the X direction. Normalized in the range -1...1 */
+  float    yrel;    /**< The relative motion in the Y direction. Normalized in the range -1...1 */
 };
 
 enum EWindowEventID

--- a/src/Application/UIPanGestureRecognizer.cpp
+++ b/src/Application/UIPanGestureRecognizer.cpp
@@ -94,7 +94,7 @@ void UIPanGestureRecognizer::touchesMoved(UEvent e)
 
 void UIPanGestureRecognizer::touchesEnded(UEvent e)
 {
-  translate(m_lastDelta); // no more movement, use the last delta to calculate velocity
+  m_velocity = m_lastVelocity; // no more movement, use the last velocity
   setState(EUIGestureRecognizerState::ENDED);
   if (e.type == VGG_TOUCHUP)
     DEBUG("UIPanGestureRecognizer::touchesEnded: touch up");
@@ -112,7 +112,8 @@ bool UIPanGestureRecognizer::translate(Point delta)
     return false;
 
   const auto now = nowTimestampInSeconds();
-  const auto timeDiff = now - m_lastMovementTime; // may be zero
+  const auto timeDiff = now - m_lastMovementTime; // may be ZERO
+  m_lastMovementTime = now;
 
   m_translation.x += delta.x;
   m_translation.y += delta.y;
@@ -124,9 +125,9 @@ bool UIPanGestureRecognizer::translate(Point delta)
       "UIPanGestureRecognizer::translate: velocity: x = %f, y = %f",
       m_velocity.x,
       m_velocity.y);
+    m_lastVelocity = m_velocity;
   }
-  m_lastMovementTime = now;
-  m_lastDelta = delta;
+
   return true;
 }
 

--- a/src/Application/UIPanGestureRecognizer.cpp
+++ b/src/Application/UIPanGestureRecognizer.cpp
@@ -24,7 +24,8 @@
 #undef DEBUG
 #define DEBUG(msg, ...)
 
-using namespace VGG::UIKit;
+namespace VGG::UIKit
+{
 
 void UIPanGestureRecognizer::touchesBegan(UEvent e)
 {
@@ -95,6 +96,8 @@ void UIPanGestureRecognizer::touchesEnded(UEvent e)
 {
   translate(m_lastDelta); // no more movement, use the last delta to calculate velocity
   setState(EUIGestureRecognizerState::ENDED);
+  if (e.type == VGG_TOUCHUP)
+    DEBUG("UIPanGestureRecognizer::touchesEnded: touch up");
 }
 
 void UIPanGestureRecognizer::setTranslation(Point translation)
@@ -105,27 +108,26 @@ void UIPanGestureRecognizer::setTranslation(Point translation)
 
 bool UIPanGestureRecognizer::translate(Point delta)
 {
-  auto now = nowTimestampInSeconds();
-  auto timeDiff = now - m_lastMovementTime;
+  if (delta == Point::zero())
+    return false;
 
-  if ((delta != Point::zero()) && timeDiff > 0)
+  const auto now = nowTimestampInSeconds();
+  const auto timeDiff = now - m_lastMovementTime; // may be zero
+
+  m_translation.x += delta.x;
+  m_translation.y += delta.y;
+  if (timeDiff > 0)
   {
-    m_translation.x += delta.x;
-    m_translation.y += delta.y;
     m_velocity.x = delta.x / timeDiff;
     m_velocity.y = delta.y / timeDiff;
     DEBUG(
-      "UIPanGestureRecognizer::translate: vecocity: x = %f, y = %f",
+      "UIPanGestureRecognizer::translate: velocity: x = %f, y = %f",
       m_velocity.x,
       m_velocity.y);
-    m_lastMovementTime = now;
-    m_lastDelta = delta;
-    return true;
   }
-  else
-  {
-    return false;
-  }
+  m_lastMovementTime = now;
+  m_lastDelta = delta;
+  return true;
 }
 
 Point UIPanGestureRecognizer::translation()
@@ -146,3 +148,5 @@ void UIPanGestureRecognizer::setState(EUIGestureRecognizerState state)
     m_handler(*this);
   }
 }
+
+} // namespace VGG::UIKit

--- a/src/Application/UIPanGestureRecognizer.hpp
+++ b/src/Application/UIPanGestureRecognizer.hpp
@@ -31,10 +31,10 @@ public:
 
 private:
   double m_lastMovementTime;
-  Point  m_lastDelta;
 
   Point m_translation;
   Point m_velocity;
+  Point m_lastVelocity;
 
   TPanHandler m_handler;
 


### PR DESCRIPTION
### Description
Fixed #400 :
* If touchmove event interval is zero, scrolling should still occur
* Pan gesture end velocity should use last velocity