### PR TITLE
Bugfix resize node

### DIFF
--- a/include/Domain/Layout/LayoutNode.hpp
+++ b/include/Domain/Layout/LayoutNode.hpp
@@ -288,6 +288,7 @@ private:
 
   bool shouldSkip();
   bool isBooleanGroup();
+  bool hasRotation();
 
   void updatePathNodeModel(
     const Layout::Rect&                     newFrame,

--- a/src/Domain/Layout/LayoutNode.cpp
+++ b/src/Domain/Layout/LayoutNode.cpp
@@ -692,18 +692,8 @@ Layout::Rect LayoutNode::resize(
     newFrame.origin = newOrigin;
   }
 
-  // handle parent origin
-  if (auto p = parent())
-  {
-    const auto& parentOrigin = p->modelBounds().origin.makeFromModelPoint();
-    newOrigin = newOrigin - parentOrigin;
-    newFrame.origin = newOrigin;
-  }
-
   if (!dry)
-  {
     setFrame(newFrame, true, true); // udpate layout rule by constraint
-  }
 
   return newFrame;
 }

--- a/test/domain/layout/resizing_tests.cpp
+++ b/test/domain/layout/resizing_tests.cpp
@@ -511,8 +511,7 @@ TEST_F(VggResizingTestSuite, HandleParentOrigin)
     EXPECT_TRUE(bounds == expectedBounds[0]);
   }
   {
-    std::vector<Layout::Rect> expectedFrames{ { { 318.27272727272725, 978.71428571428577 },
-                                                { 1920, 1080 } } };
+    std::vector<Layout::Rect> expectedFrames{ { { 0, 0 }, { 1920, 1080 } } };
     EXPECT_TRUE(descendantFrame({ 0 }, 0) == expectedFrames[0]);
   }
 }


### PR DESCRIPTION
### Description
Fixed:
* When resizing a node whose parent node has a non-zero origin, use relative positions to calculate
